### PR TITLE
🐛 Fix CLEAR Growth score inconsistency in scoring engine post

### DIFF
--- a/app/routes/thoughts.building-the-scoring-engine.mdx
+++ b/app/routes/thoughts.building-the-scoring-engine.mdx
@@ -114,13 +114,13 @@ Two real examples from my evaluations.
 |---|---|---|
 | Valuation | 5 / 5 | Analyst upside +32% |
 | Quality | 5 / 5 | ROE 76%, gross margin 86%, net cash |
-| Growth | 5 / 5 | Revenue up 17% YoY, $343M FCF |
+| Growth | 4 / 5 | Revenue up 17% YoY, $343M FCF |
 | Risk | 4 / 5 | Beta 1.10, retention declining |
-| **Quantitative** | **4.80** | |
+| **Quantitative** | **4.60** | |
 
 **Strategic — 3.00.** Skipping the airport security line is a real annoyance, but people have flown without CLEAR for decades. TSA PreCheck solves roughly 70% of the same pain at $78 for five years versus $209 per year, and United just cut the free CLEAR benefit for elite flyers — a quiet signal that even the airlines no longer see it as indispensable. **Problem: 3/5.** CLEAR has built genuine infrastructure — 38 million biometric profiles, physical eGates in 37 airports — that takes years to replicate. But that protects the supplier, not the user. A traveler cancels the $209 subscription online, walks back to the TSA PreCheck line, and nothing breaks. Retention is already declining to 86%. **Defensibility: 3/5.**
 
-**Total: 3.79 (Strong).** Excellent financials hiding a fragile thesis. CLEAR has scale and a cornered resource on the infrastructure side, but no switching costs on the user side — and a moat that only works for the supplier is half a moat. A full tier below what the numbers alone would suggest.
+**Total: 3.71 (Strong).** Excellent financials hiding a fragile thesis. CLEAR has scale and a cornered resource on the infrastructure side, but no switching costs on the user side — and a moat that only works for the supplier is half a moat. A full tier below what the numbers alone would suggest.
 
 ## What the framework favors
 


### PR DESCRIPTION
## Summary

Pre-existing inconsistency between the threshold table and the CLEAR (YOU) worked example in the scoring engine post.

The post's threshold table specifies **Growth 5 requires Revenue CAGR 3yr >20%**. The CLEAR example scored Growth 5/5 based on *"Revenue up 17% YoY"* — which actually falls in the 10-20% bucket and should be a 4.

Cascading corrections:

| Field | Before | After |
|---|---|---|
| Growth | 5 / 5 | 4 / 5 |
| Quantitative | 4.80 | 4.60 |
| Score Total | 3.79 | 3.71 |

### Math verification

- Quantitative: `5×0.30 + 5×0.30 + 4×0.20 + 4×0.20 = 4.60`
- Score Total: `√(4.60 × 3.00) = √13.80 ≈ 3.71`
- Classification: 3.71 remains in the 3.5–4.4 bucket → **Strong** (unchanged)

### What doesn't change

- The narrative ("Excellent financials hiding a fragile thesis")
- The Strategic score (3.00)
- The classification (Strong)
- Everything else in the post

### Why now

The inconsistency has been in the post since publication (pre-v2.3 framework). Surfaced during the v2.3 framework review in the atlas repo when cross-checking published examples against the thresholds. Not caused by v2.3 — v2.3 doesn't change any of the thresholds or weights involved in this calculation.
