### PR TITLE
📝 Update The Missing Why for v2.4.1

### DIFF
--- a/app/routes/thoughts.the-missing-why.mdx
+++ b/app/routes/thoughts.the-missing-why.mdx
@@ -44,35 +44,33 @@ Third, re-evaluations become mechanical. Every quarter I update the quantitative
 
 A hypothesis is not a vague belief. "AI will change the world" is not a hypothesis. "Enterprise AI spending will grow more than twenty-five percent annually through 2028" is, because you can check it, and you know when you are wrong.
 
-Each hypothesis in my system has five components:
+Each hypothesis in my system has three layers:
 
-- A **falsifiable statement** about the future with a specific time horizon
-- **Confirming signals:** concrete, observable events I should look for
-- **Falsifying signals:** concrete, observable events that would invalidate the belief
-- A **status:** active, weakening, or falsified
-- **Linked positions:** which holdings depend on this belief being true
+- A **macro belief** about the world, with a time horizon. This must not mention a specific company. "Pharma will consolidate on cloud platforms by 2030" is a macro belief. "Veeva will win the pharma market" is not.
+- **Company links** that explain how each position captures the trend, including the **capture risk**: who else could capture it, how, and what evidence exists today. This is the most important field. The macro can be correct and the company can still lose.
+- **Signals** with measurable thresholds, both confirming and falsifying, plus a status: active, weakening, or falsified.
 
 The status matters more than it seems. "Weakening" without a date is dangerous. You can sit in weakening for eighteen months without acting because the hypothesis never formally crossed to falsified. So I added a rule: if a hypothesis has been weakening for more than twelve months without new confirming evidence, treat it as falsified and re-evaluate every linked position.
 
 ## Two examples
 
-**Veeva, the strongest hypothesis.**
+**Veeva, where the separation matters most.**
 
-The top twenty pharma companies will consolidate from dozens of point solutions to a unified cloud platform for CRM, clinical, regulatory, quality, and safety.
+The macro: the top twenty pharma companies will consolidate from dozens of point solutions to a unified cloud platform by 2030. There is a hard deadline. Every customer on Veeva's Salesforce-hosted CRM must migrate by September 2030.
 
-- **Confirming signals:** 10 of the top 20 have committed to Vault CRM: Merck in July 2025, Roche in November, Novo Nordisk in January 2026. Revenue hit 3.2 billion dollars, up sixteen percent. AI agents launched in December 2025, with more modules planned through 2026.
-- **Falsifying signals:** A top-20 pharma rejecting Vault CRM, migration disruptions slowing adoption, or a GenAI-native competitor offering a credible alternative. None active.
-- **Status:** Active. Five out of five confirming signals fired. The migration timeline stretches from 2026 to 2029, which means multi-year visibility that no quarterly earnings report can provide.
+- **Macro signals:** The consolidation is happening. Nine of the top twenty have committed to Veeva's Vault CRM: Merck, Roche, Novo Nordisk, GSK, Bayer, and others. Revenue hit 3.2 billion dollars, up sixteen percent. The migration timeline stretches from 2026 to 2029.
+- **Capture risk:** Salesforce launched Life Sciences Cloud in September 2025 with IQVIA as partner. AstraZeneca, Novartis, Takeda, and Pfizer chose Salesforce. About eight of the top twenty remain undecided. The macro is confirmed, but the market is bifurcating, not winner-take-all. I defined a falsifier: if five or more of the top twenty choose Salesforce, the capture thesis weakens. That number is at three to five today.
+- **Status:** Active, but with elevated capture risk. The macro is strong. The company capture is being contested.
 
-**Visa, the weakest hypothesis.**
+**Visa, where the macro is almost a fact.**
 
-Digital payments will continue displacing cash globally and card networks will capture that growth.
+The macro: digital payments will continue displacing cash globally. This is barely a hypothesis. 2026 is the first year in history when more than half of global consumer payments use card credentials. The real question is whether card networks capture the growth or get bypassed.
 
-- **Confirming signals:** 2026 is the first year in history when more than half of global consumer payments use card credentials. Sixty percent of the global population is expected to use digital wallets this year.
-- **Falsifying signals:** This is where the cracks show. India's UPI system processes thirteen billion real-time transactions per month, seventy-one percent of all transactions in the country. Credit card market share in India fell from forty-three percent in 2018 to twenty-one percent in 2024. Brazil's Pix is following the same playbook. In the US, FedNow has over fifteen hundred participating institutions, up forty-four percent year over year. None of these are triggering yet. FedNow's share of consumer point-of-sale payments is near zero. But India built a national payment rail that bypasses card networks entirely, and the question is whether other markets follow.
-- **Status:** Active, but the closest to weakening of any hypothesis in my portfolio. Confirming and falsifying signals are active simultaneously.
+- **Macro signals:** Confirmed. Sixty percent of the global population is expected to use digital wallets this year.
+- **Capture risk (two independent threats):** First, state-backed real-time payment systems. India's UPI processes thirteen billion transactions per month, seventy-one percent of all transactions in the country. Credit card market share in India fell from forty-three percent in 2018 to twenty-one percent in 2024. Brazil's Pix is following the same trajectory. In the US, FedNow has over sixteen hundred participating banks, up forty-four percent year over year, though consumer point-of-sale share is near zero. Second, regulatory. The DOJ filed an antitrust lawsuit alleging Visa has a debit monopoly, with a potential trial in late 2027. The Credit Card Competition Act was reintroduced in January 2026 and would force cards to offer two unaffiliated networks, breaking Visa's bundling power.
+- **Status:** Active, but the weakest in the portfolio. The macro is a fact. The capture has two independent threats, either of which alone would hurt, both together would be transformational.
 
-Both companies score well. Both passed the same quantitative and strategic evaluation. But the conviction behind each position is fundamentally different, and the hypothesis makes that difference visible in a way the scores alone cannot.
+Both companies score well. Both passed the same quantitative and strategic evaluation. In both cases, the macro is confirmed. The difference is in the capture: Veeva faces a real competitor for the first time, and Visa faces two structural threats converging independently. The hypothesis makes that visible in a way the scores alone cannot.
 
 ## What hypotheses do not do
 


### PR DESCRIPTION
## Summary

Updates post 3 to reflect the macro/capture separation from framework v2.4.1.

- **Structure section:** "five components" replaced with "three layers" (macro belief, company links with capture risk, signals)
- **VEEV example:** Honest about Salesforce LSC competition. Falsifier at 3-5 of 5 threshold. Capture risk elevated.
- **V example:** Added DOJ antitrust + Credit Card Competition Act as second capture risk alongside RTP/A2A.
- Both examples now demonstrate the key insight: macro confirmed, capture contested.
