### PR TITLE
Restore flow in both posts: connect fragments with colons and conjunctions

### DIFF
--- a/app/routes/thoughts.evaluating-stocks-1-the-problem.mdx
+++ b/app/routes/thoughts.evaluating-stocks-1-the-problem.mdx
@@ -20,11 +20,11 @@ export const meta = () => [
   <span>{formatDate(frontmatter.date)}</span>
 </time>
 
-Since mid-2024 I've worked as a lead engineer at Summit Management, a hedge fund. My job is the fund's system. Data pipelines, scoring engines, the infrastructure behind investment decisions.
+Since mid-2024 I've worked as a lead engineer at Summit Management, a hedge fund. My job is the fund's system: data pipelines, portfolio returns and performance, the infrastructure behind investment decisions.
 
-Along the way I picked up the basics. P/E ratios, ROIC, debt-to-equity, revenue growth. Enough to follow the conversation, not enough to call myself an analyst. At some point I asked myself something simple. If I were to invest my own money, what would I actually look for?
+Along the way I picked up the basics: P/E ratios, ROIC, debt-to-equity, revenue growth. Enough to follow the conversation, not enough to call myself an analyst. At some point I asked myself a simple question: if I were to invest my own money, what would I actually look for?
 
-I'm a product engineer. Years doing both sides, product and tech. That shapes how I think. I build software, but I also ask whether something should exist at all. Is the problem real? Must-have or nice-to-have? What happens if nobody solves it? What are the alternatives? Those are the questions that build conviction for me.
+I'm a product engineer. I've spent years on both sides, product and tech, and that shapes how I think. I build software, but I also ask whether something should exist at all. Is the problem real? Must-have or nice-to-have? What happens if nobody solves it? What are the alternatives? Those are the questions that build conviction for me.
 
 The natural place to apply them was the company itself. That instinct was half right. The questions were the right questions. The subject was not.
 
@@ -35,7 +35,7 @@ It splits in two, and the order matters:
 - **The thesis.** The permanent need itself, scored on its own without any company attached. If the need is not real or not durable, no company matters.
 - **The player.** A candidate that might capture the thesis. Scored on the business itself, on its defensibility, and on how much of it actually points at the thesis. If the candidate doesn't capture the need, the financials don't matter.
 
-Both have to hold. A thesis that's alive and a player that's strong enough. One doesn't save the other.
+Both have to hold: a thesis that's alive and a player that's strong enough. One doesn't save the other.
 
 This post is about the thesis. The player comes next.
 
@@ -43,11 +43,11 @@ This post is about the thesis. The player comes next.
 
 The natural starting point is the company, because the company is what you can actually buy. Pick one, run the product questions on it, decide. The trouble is that by the moment you've picked, you've already chosen the problem to evaluate. "Is this problem real" turns into confirmation, not exploration.
 
-Starting from the world reverses the order. Articulate the problem first. Then ask who could capture it. Companies become candidates, not the unit. So instead of asking whether MSCI is a good business, I ask whether benchmarking institutional money is a permanent need. If yes, MSCI is one of the names worth a look. If no, MSCI isn't interesting at any score.
+Starting from the world reverses the order. Articulate the problem first, then ask who could capture it. Companies become candidates, not the unit. So instead of asking whether MSCI is a good business, I ask whether benchmarking institutional money is a permanent need. If yes, MSCI is one of the names worth a look. If no, MSCI isn't interesting at any score.
 
 ## What a thesis is
 
-So what counts as a real thesis. Not a vague belief. "AI will change the world" is not a thesis. "Pension funds, ETFs, and insurers are required by law to measure performance against externally administered benchmarks, and that requirement won't go away" is. Because I can check it, and I know what would make me wrong. That sentence is the start of a real thesis I keep in my registry. I call it **Financial Index** and I'll use it as the example throughout.
+So what counts as a real thesis? Not a vague belief. "AI will change the world" isn't a thesis. But "pension funds, ETFs, and insurers are required by law to measure performance against externally administered benchmarks, and that requirement won't go away" is, because I can check it and I know what would make me wrong. That sentence is the start of a real thesis I keep in my registry, called **Financial Index**. I'll use it as the example throughout.
 
 Each thesis I keep has five pieces:
 
@@ -61,15 +61,15 @@ These are below. The roster gets its own section after them.
 
 ### Problem Score
 
-One to five, how severe and durable the problem is. Four sub-questions feed into it. Does anyone solve it without this kind of provider? Is it must-have? Is it mandated by regulation? Is it getting worse? A five is critical infrastructure, mandated or close to it. A one is a perceived problem with no urgency.
+One to five, how severe and durable the problem is. Four sub-questions feed in: whether anyone solves it without this kind of provider, whether it's must-have, whether regulation mandates it, and whether it's getting worse. A five is critical infrastructure, mandated or close to it. A one is a perceived problem with no urgency.
 
 Financial Index scores a 5 on all four. ERISA, MiFID II, and Solvency II all enforce some version of the mandate. There is no parallel solver structure outside externally administered benchmarks.
 
 ### Base rate
 
-Problem Score is an inside view. It tells me how severe the need looks on its own merits. Base rate is the outside-view check. How often have needs in the same class actually survived over the long run?
+Problem Score is an inside view: how severe and durable the need looks on its own merits. Base rate is the outside-view check: how often have needs in the same class actually survived over the long run?
 
-The reference class for Financial Index is independent third-party financial-data infrastructure providers operating under explicit regulatory recognition. The Big-3 credit ratings (post-1975), the Big-3 index providers, CUSIP (single-vendor since 1968), CRSP. Across the last forty years, seven incumbents preserved top-3 dominance in their primary asset class. Around ten entrants tried. Zero displaced an incumbent in a core asset class. The base rate of preserved dominance sits at 85%.
+The reference class for Financial Index is independent third-party financial-data infrastructure providers operating under explicit regulatory recognition: the Big-3 credit ratings (post-1975), the Big-3 index providers, CUSIP (single-vendor since 1968), CRSP. Across the last forty years, seven incumbents preserved top-3 dominance in their primary asset class, and around ten entrants tried without displacing a single one. The base rate of preserved dominance sits at 85%.
 
 The inside-view adjustment is that index providers carry deeper lock-in than the rest of the class. Switching a benchmark breaks a public fund prospectus (SEC Form N-1A, Rule 6c-11) and triggers an ERISA fiduciary review. That's a stronger constraint than the internal contracts behind credit ratings or identifiers. Index revenue also rides global AUM growth instead of issuance cycles, which compounds the durability the 85% already captures. The expected players sit in the upper tail of the reference class.
 
@@ -96,7 +96,7 @@ Signals come in two directions.
 
 Falsifiers come first. The discipline they impose is what makes everything else work. If I can't write down what would make me wrong, I don't have a thesis. I have a feeling.
 
-Both come from adversarial research. Queries designed to break the thesis, not to confirm it. If I can't find a primary source for a claim, the claim doesn't make it in.
+Both come from adversarial research, queries designed to break the thesis rather than confirm it. If I can't find a primary source for a claim, the claim doesn't make it in.
 
 Open falsifiers under Financial Index:
 
@@ -130,7 +130,7 @@ Financial Index is Alive.
 
 ## Filters before the roster
 
-Not every alive thesis becomes investable. Some need sectors I can't evaluate from primary sources. Biotech mechanism-of-action, deep semiconductor process economics, opaque commodity chains. Those go to a "too hard" list. Neither alive nor falsified. Just outside the lens. Financial infrastructure is inside.
+Not every alive thesis becomes investable. Some sit in sectors I can't evaluate from primary sources, like biotech mechanism-of-action, deep semiconductor process economics, or opaque commodity chains. Those go to a "too hard" list, neither alive nor falsified, just outside the lens. Financial infrastructure is inside.
 
 ## The roster
 
@@ -144,13 +144,13 @@ The Financial Index roster:
 | Ecosystem | Bank for International Settlements, IMF, IOSCO, CFA Institute |
 | Regulators | SEC, US Department of Labor, ESMA, UK Financial Conduct Authority |
 
-What does a quarterly signal look like? A new SEC rule on ETF index licensing. A competitor cutting prices on a thematic index family. A new IOSCO principle on benchmark administration. None of these moves quarterly numbers immediately. Each is a signal about the thesis. The roster is what makes the thesis monitorable.
+What does a quarterly signal look like? A new SEC rule on ETF index licensing, a competitor cutting prices on a thematic index family, a new IOSCO principle on benchmark administration. None of these moves quarterly numbers immediately, but each is a signal about the thesis. The roster is what makes the thesis monitorable.
 
 The cascade also runs the other way. If the thesis is Falsified, every position under it exits with it, no matter how strong the player looked on its own. Player strength does not save a dead thesis.
 
 ## What this changes
 
-The questions I started with are still the questions. Is the problem real, must-have, getting worse, what happens without it. What I changed is where I point them. Not at the company. At the world's need. The company shows up as one of the candidates the need lets in.
+The questions I started with are still the questions. Is the problem real, must-have, getting worse, what happens without it. What I changed is where I point them: not at the company, but at the world's need. The company shows up as one of the candidates the need lets in.
 
 What I haven't covered is how I pick a candidate once the need has a roster. That's the next post.
 

--- a/app/routes/thoughts.evaluating-stocks-2-the-players.mdx
+++ b/app/routes/thoughts.evaluating-stocks-2-the-players.mdx
@@ -20,23 +20,23 @@ export const meta = () => [
   <span>{formatDate(frontmatter.date)}</span>
 </time>
 
-In a [previous post](/thoughts/evaluating-stocks-1-the-problem) I described the first half of the framework: the thesis. The permanent need, scored on its own without any company attached. Five pieces, plus a roster of who could capture the need.
+In a [previous post](/thoughts/evaluating-stocks-1-the-problem) I described the first half of the framework: the thesis. The permanent need, scored on its own without any company attached, in five pieces plus a roster of who could capture it.
 
-The roster is where this post starts. Once the thesis is alive and the roster exists, the question turns: which of these players is worth committing capital to. A thesis without a player is just a forecast. A player without a thesis is just a stock.
+The roster is where this post starts. Once the thesis is alive and the roster exists, the question becomes which of these players is worth committing capital to. A thesis without a player is just a forecast. A player without a thesis is just a stock.
 
 This post is about how I score the players, and the two gates that decide whether any of them stays.
 
 ## What's on the roster
 
-The roster I introduced last time was not a list of competitors. It was deliberately wider than that. The registry tracks three types of entries.
+The roster I introduced last time was not a list of competitors. It was deliberately wider, tracking three types of entries.
 
 - **Competitor.** A public or private entity capturing the need today, or aiming to.
-- **Regulator.** Sets or enforces the rules that shape the capture surface. SEC, ESMA, FCA, DOL.
-- **Ecosystem.** Doesn't compete for the customer but shapes the market. BIS, IMF, IOSCO, CFA Institute.
+- **Regulator.** Sets or enforces the rules that shape the capture surface, like the SEC, ESMA, FCA, or DOL.
+- **Ecosystem.** Doesn't compete for the customer but shapes the market, like the BIS, IMF, IOSCO, or CFA Institute.
 
 Only competitors are investable. Regulators and ecosystem participants show up in the roster because their actions are signals about the thesis, not because I plan to buy them. They get watched, not scored. You don't score the SEC. You watch what it does.
 
-Among the competitors, two more states show up as I evaluate them. A competitor under active evaluation for entry becomes a **candidate**. A candidate that passes both gates becomes a **position**. These come out of the scoring, not at the start. The same player moves between them as the evaluation evolves. If a competitor on the roster pulls ahead of the current position on signals, the thesis is still alive. A different player is just now the better vehicle for it.
+Among the competitors, two more states show up as I evaluate them. A competitor under active evaluation for entry becomes a **candidate**. A candidate that passes both gates becomes a **position**. These come out of the scoring, not at the start. The same player moves between them as the evaluation evolves. If a competitor on the roster pulls ahead of the current position on signals, the thesis is still alive, just with a different player now serving as the better vehicle for it.
 
 For the rest of this post, "player" means a competitor under scoring.
 
@@ -44,9 +44,9 @@ For the rest of this post, "player" means a competitor under scoring.
 
 Every investable player has three numbers that combine into a final Player Strength.
 
-- **Quant Score (1 to 5).** The financial profile of the business. Quarterly filings rolled into trailing-twelve-month numbers, plus current price and consensus forecasts where needed.
-- **Defensibility (1 to 5).** The moat structure. Eight Powers, each rated on whether the benefit exists, the barrier holds, and the trend is stable, eroding, or strengthening.
-- **Thesis Focus (1 to 5).** How much of the player's actual operations point at this specific thesis. Identified primarily from the 10-K segment disclosure.
+- **Quant Score (1 to 5).** The financial profile of the business, built from quarterly filings rolled into trailing-twelve-month numbers plus current price and consensus forecasts where needed.
+- **Defensibility (1 to 5).** The moat structure: eight Powers, each rated on whether the benefit exists, the barrier holds, and the trend is stable, eroding, or strengthening.
+- **Thesis Focus (1 to 5).** How much of the player's actual operations point at this specific thesis, identified primarily from the 10-K segment disclosure.
 
 The three combine through one formula:
 
@@ -60,10 +60,10 @@ I'll use **MSCI under the Financial Index thesis** as the running example, same 
 
 Four dimensions, each scored one to five, combined as a weighted average.
 
-- **Valuation (30%).** Reverse DCF verdict. Solve for the growth, margin, and discount-rate path that justifies today's price. The verdict is plausible, fair, stretched, implausible, or a math violation. Plausible scores a five. Implausible scores a one.
-- **Quality (30%).** ROIC plus gross margin, with earnings-quality caps. Does the business generate real returns above its cost of capital, and are the earnings clean.
-- **Growth (20%).** Three-year revenue CAGR plus trailing or forward EPS year-over-year. Is the company actually expanding, and is that expansion converting to per-share earnings.
-- **Risk (20%).** Beta against SPY plus debt-to-equity. How leveraged and volatile is the business.
+- **Valuation (30%).** Reverse DCF verdict: solve for the growth, margin, and discount-rate path that justifies today's price. The verdict is plausible, fair, stretched, implausible, or a math violation. Plausible scores a five, implausible scores a one.
+- **Quality (30%).** ROIC plus gross margin, with earnings-quality caps. Does the business generate real returns above its cost of capital, and are the earnings clean?
+- **Growth (20%).** Three-year revenue CAGR plus trailing or forward EPS year-over-year. Is the company actually expanding, and is that expansion converting to per-share earnings?
+- **Risk (20%).** Beta against SPY plus debt-to-equity. How leveraged and volatile is the business?
 
 The thresholds:
 
@@ -77,19 +77,19 @@ The thresholds:
 | Beta | 0.7-1.0 | 1.0-1.2 | 1.2-1.5 | 1.5-2.0 | > 2.0 |
 | Debt-to-equity | < 0.3 | 0.3-0.7 | 0.7-1.0 | 1.0-1.5 | > 1.5 |
 
-Two earnings-quality gates run alongside Quality. An Accrual Ratio Alert flags when accruals diverge from cash flow. A Quality Signal Count from the Piotroski subset checks three things. Operating cash flow above net income, share count not rising, long-term debt as a share of assets not rising. If either gate fires, the Quality dimension is capped, regardless of how good ROIC and gross margin look.
+Two earnings-quality gates run alongside Quality. An Accrual Ratio Alert flags when accruals diverge from cash flow. A Quality Signal Count from the Piotroski subset checks three things: operating cash flow above net income, share count not rising, and long-term debt as a share of assets not rising. If either gate fires, the Quality dimension is capped, regardless of how good ROIC and gross margin look.
 
 MSCI scores **4.30 / 5** on Quant.
 
 ### Defensibility
 
-Hamilton Helmer's 7 Powers, plus a split that breaks Cornered Resource into Structural and Regulatory. Eight powers in total, each rated on three axes:
+Hamilton Helmer's 7 Powers, with Cornered Resource split into Structural and Regulatory. Eight in total, each rated on three axes:
 
 - **Rating (1 to 5).** Does the power exist for this player today.
 - **Benefit (1 to 5).** How much does the power translate into profitability.
 - **Barrier (1 to 5).** How hard is it for someone with more resources to replicate.
 
-Each one also carries a trend over the last few quarters. Stable, eroding, or strengthening.
+Each one also carries a trend over the last few quarters: stable, eroding, or strengthening.
 
 The eight Powers:
 
@@ -117,24 +117,24 @@ For MSCI:
 | Process power | 4 | 4 | 4 | stable |
 | Counter-positioning | 3 | 3 | 3 | eroding |
 
-Six Powers stable, two eroding. Switching costs carry the moat: changing benchmarks breaks public ETF prospectuses (SEC Form N-1A, Rule 6c-11) and triggers ERISA fiduciary review. The two eroding Powers are the ones I monitor most. Counter-positioning is under pressure from Morningstar's CRSP acquisition. Regulatory cornering is exposed to FCA FRAND remedies.
+Six Powers stable, two eroding. Switching costs carry the moat: changing benchmarks breaks public ETF prospectuses (SEC Form N-1A, Rule 6c-11) and triggers ERISA fiduciary review. The two eroding Powers are the ones I monitor most: counter-positioning under pressure from Morningstar's CRSP acquisition, and regulatory cornering exposed to FCA FRAND remedies.
 
 Blended Defensibility: **4.40 / 5**.
 
-The eight Powers are a structural lens. For software businesses I add a product-manager lens on top. Four questions whose answers don't always show up in a 10-K.
+The eight Powers are a structural lens. For software businesses I add a product-manager lens on top, four questions whose answers don't always show up in a 10-K.
 
 - How painful is it for a customer to migrate away?
 - Does the user live inside the application all day?
 - Does the product get smarter with more data?
 - Is there a free alternative that solves eighty percent of the problem?
 
-The PM lens sharpens specific Powers (mostly Switching costs, Network effects, Process power) and catches cases where a player clears every structural test and still feels fragile. For MSCI, all four resolve toward the moat. Migration breaks the public ETF prospectus. The institutional asset manager lives in the methodology daily. The product gets denser with every new ETF launched against an MSCI index. There is no free 80% alternative for a fund mandated to use externally administered benchmarks.
+The PM lens sharpens specific Powers (mostly Switching costs, Network effects, Process power) and catches cases where a player clears every structural test and still feels fragile. For MSCI, all four resolve toward the moat: migration breaks the public ETF prospectus, the institutional asset manager lives in the methodology daily, the product gets denser with every new ETF launched against an MSCI index, and there's no free 80% alternative for a fund mandated to use externally administered benchmarks.
 
 ### Thesis Focus
 
 A great company can be the wrong vehicle for a thesis. Defensibility tells me whether the player has a moat. Thesis Focus tells me whether that moat is pointing at the need I am trying to capture.
 
-Most public companies break out revenue by operating segment in the 10-K. The question is simple. What percentage of the player's revenue comes from segments that actually capture this thesis. Segments don't overlap in primary disclosure, so the percentages add up cleanly.
+Most public companies break out revenue by operating segment in the 10-K. The question is simple: what percentage of the player's revenue comes from segments that actually capture this thesis. Segments don't overlap in primary disclosure, so the percentages add up cleanly.
 
 The mapping from segment percentage to score:
 
@@ -146,7 +146,7 @@ The mapping from segment percentage to score:
 | 20-40% | 2 |
 | < 20% | 1 |
 
-One small refinement. If the thesis-aligned segment is not just the largest by revenue but also the largest by profit and the largest by growth, the score moves up one band. The intuition is that a segment dominating all three legs is doing real work for the thesis even when the percentage looks moderate. If only revenue dominance holds, the score stays at the literal band.
+One small refinement: if the thesis-aligned segment is not just the largest by revenue but also the largest by profit and the largest by growth, the score moves up one band. The intuition is that a segment dominating all three legs is doing real work for the thesis even when the percentage looks moderate. If only revenue dominance holds, the score stays at the literal band.
 
 When a player spans more than one registered thesis, each linkage counts when the segment is at least 20% of revenue and the linked thesis is alive or searching. The single-thesis case is the common one.
 
@@ -182,7 +182,7 @@ A few of MSCI's open falsifiers:
 - The BlackRock 2035 contract Index asset-based fee yield declines more than 5% year over year for two consecutive quarters.
 - Direct-indexing AUM displaces standardized index licensing at scale, with MSCI Index segment growth decelerating below 3% for two consecutive years.
 
-When a capture-layer falsifier fires, it doesn't kill the position by itself. It feeds back into the underlying scores. A Power rating drops, the Quant verdict turns lower, or the Thesis Focus needs a revisit. The two gates fire from the scores, not directly from the signals.
+When a capture-layer falsifier fires, it doesn't kill the position by itself. It feeds back into the underlying scores: a Power rating drops, the Quant verdict turns lower, or the Thesis Focus needs a revisit. The two gates fire from the scores, not directly from the signals.
 
 ## The two gates
 
@@ -195,7 +195,7 @@ Both must be true. There are no overrides.
 
 The two gates close different failure modes. If only Player Strength gated entry, a thesis could quietly be falsified while the player kept scoring well, and I would hold a strong vehicle pointing at a dead need. If only Thesis Alive gated entry, a player could degrade structurally while the thesis stayed valid, and I would hold a weakening vehicle in a healthy market.
 
-Exit is symmetric. Thesis Falsified or Player Strength below 3.0 forces an exit. The cascade from the previous post still applies. A dead thesis takes every position with it.
+Exit is symmetric. Thesis Falsified or Player Strength below 3.0 forces an exit, and the cascade from the previous post still applies: a dead thesis takes every position with it.
 
 What the gates don't tell me is how much capital each position should carry. Position sizing comes from the Strength tier table above, plus adjustments for sector concentration and correlation. And the gates say nothing about when to add or trim inside an existing position. That's a different mechanism, and one I'll write about separately.
 


### PR DESCRIPTION
## Summary

Round 2 of both posts left the prose too staccato. Replacing compound sentences with short fragments created a different problem: the writing stopped reading as paragraphs and started reading as bullet points stuck in prose. This PR reconnects fragments using colons, commas, and conjunctions (no em-dashes, no semicolons).

Covers **both Post 1 (The Problem)** and **Post 2 (The Players)** in a single PR since the issue is the same in both files and the fixes are the same shape.

## Post 1 — flow fixes

- "Fund's system" list now connects with a colon
- Basics list folds into the prior sentence via a colon
- "Years on both sides" gets a connecting clause
- "Both have to hold" uses a colon to introduce the elaboration
- "Articulate the problem first, then ask..." as one sentence
- **Rewrites the "So what counts as a real thesis" paragraph** that the user flagged as choppy: adds the question mark, uses "But" to bridge, folds "because I can check it" back into the same sentence
- Problem Score / Base rate definitions connect with colons
- The four-question Problem Score opener collapses into one flowing sentence
- Reference-class example list connects with a colon
- "Around ten entrants" joins the prior sentence via "and"
- Adversarial-research sentence joins its elaboration with a comma
- "Too hard list" paragraph reads as one sentence
- Quarterly-signal examples become a single comma list
- Closer: "not at the company, but at the world's need" as one phrase

**Also fixes "scoring engines"** to "portfolio returns and performance" — the user clarified that "scoring engines" was an inaccurate guess for what they actually build at the fund.

## Post 2 — flow fixes

- Thesis-summary opener as one sentence
- "The question becomes which of these players is worth committing capital to" (was "the question turns:" which read awkwardly)
- Regulator / Ecosystem definitions connect to their example lists with "like the SEC, ESMA, ..."
- Three-numbers bullets collapse from two sentences each into one
- Valuation bullet uses a colon between verdict label and explanation
- Quality / Growth / Risk bullets get question marks on their rhetorical questions
- "Hamilton Helmer's 7 Powers, with Cornered Resource split into Structural and Regulatory" drops the redundant "eight powers in total"
- Quality Signal Count uses a colon to connect to its list
- Trend description as one sentence with a colon
- PM lens transition uses a comma instead of a split
- "Two eroding Powers" sentence with colon-introduced specifics
- PM-lens answers collapse from five short sentences into one with four colon-introduced clauses
- "The question is simple:" / "One small refinement:" / capture-layer falsifier list / cascade — all use colons
