### PR TITLE
👷 Gate Fly deploy on passing tests

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -6,8 +6,20 @@ on:
     branches:
       - master
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test
   deploy:
     name: Deploy app
+    needs: test
     runs-on: ubuntu-latest
     concurrency: deploy-group # optional: ensure only one action runs at a time
     steps:


### PR DESCRIPTION
## Summary

Adds a `test` job to `.github/workflows/fly-deploy.yml` that runs `npm test`, and gates the existing `deploy` job on it with `needs: test`. If tests fail on master, the deploy is skipped automatically — no broken-code reaches Fly.

Scope is intentionally limited to tests, not lint/build, because lint currently has 7 pre-existing errors on master (cleanup PR follows). Adding lint to the gate today would block all deploys until that cleanup ships.
