### PR TITLE
🚨 Clean up pre-existing lint errors

### DIFF
--- a/app/components/now.tsx
+++ b/app/components/now.tsx
@@ -1,4 +1,3 @@
-import { formatDistanceToNowStrict } from "date-fns";
 import { useNowListening, useNowReading, useNowWatching } from "~/lib/hooks";
 import { Skeleton } from "./ui/skeleton";
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -13,7 +13,6 @@ import {
   ScrollRestoration,
   useRouteLoaderData,
 } from "react-router";
-import { json } from "~/lib/response-helpers";
 import globalStyles from "./styles/globals.css?url";
 import { LinksFunction, LoaderFunctionArgs } from "react-router";
 import AppLayout from "./components/layouts/app-layout";

--- a/app/routes/bookmarks.tsx
+++ b/app/routes/bookmarks.tsx
@@ -22,11 +22,6 @@ export const meta: MetaFunction = () => {
   ];
 };
 
-type LoaderData = {
-  category?: Category | null;
-  bookmarks: typeof bookmarks;
-};
-
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const searchParams = new URLSearchParams(new URL(request.url).search);
   const category = searchParams.get("category");
@@ -122,7 +117,7 @@ function FilterBookmarks({
   );
 }
 
-const Item = ({ title, description, url, icon, category }: Bookmark) => {
+const Item = ({ title, description, url, icon }: Bookmark) => {
   return (
     <li>
       <a

--- a/load-context.ts
+++ b/load-context.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import { type PlatformProxy } from "wrangler";
 
 type Cloudflare = Omit<PlatformProxy<Env>, "dispose">;

--- a/scripts/trakt-auth.ts
+++ b/scripts/trakt-auth.ts
@@ -34,6 +34,7 @@ async function deviceAuth() {
   console.log("Waiting for authorization...\n");
 
   // Step 2: Poll for token
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     await new Promise((resolve) => setTimeout(resolve, interval * 1000));
 


### PR DESCRIPTION
## Summary

Brings `npm run lint` on master from **7 errors / 10 warnings** down to **0 errors / 10 warnings** with surgical fixes only. The CI gate added in #131 currently fails on master because of these pre-existing issues; this unblocks it.

## Fixes

| File | Fix |
| --- | --- |
| `app/components/now.tsx` | Remove unused `formatDistanceToNowStrict` import (only `shortTimeAgo` custom helper is used) |
| `app/root.tsx` | Remove unused `json` import from the dead path `~/lib/response-helpers` (file doesn't exist; route uses `Response.json` directly) |
| `app/routes/bookmarks.tsx` | Remove unused `LoaderData` type and the unused `category` field from `Item`'s destructure |
| `load-context.ts` | `// eslint-disable-next-line import/no-unresolved` on the type-only `wrangler` import (wrangler is not a runtime dep on Fly) |
| `scripts/trakt-auth.ts` | `// eslint-disable-next-line no-constant-condition` on the intentional `while (true)` polling loop |

## Out of scope

The 10 remaining warnings (`import/no-duplicates` from React Router type imports, `import/no-named-as-default` in `vite.config.ts`, and the long-standing `react-hooks/exhaustive-deps` in `hooks.ts`) are unchanged — they don't fail CI and would require non-trivial fixes (e.g., consolidating React Router imports across many files).

## Test plan

- [x] `npm run lint` → 0 errors locally (10 warnings remain)
- [x] `npm test` → 6/6 pass
- [x] `npm run build` → clean
- [ ] CI runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)