### PR TITLE
📝 thoughts: bump Post 2 date to 2026-05-16 for correct list sort

### DIFF
--- a/app/routes/thoughts.evaluating-stocks-2-the-business.mdx
+++ b/app/routes/thoughts.evaluating-stocks-2-the-business.mdx
@@ -1,6 +1,6 @@
 ---
   author: Óscar Córdova
-  date: 2026-05-15
+  date: 2026-05-16
   title: "Evaluating Stocks Like Products: The Business"
   description: Once the need is on the page, the question becomes who actually captures it.
 ---


### PR DESCRIPTION
## What

Both Evaluating Stocks posts shared the date 2026-05-15 after the rewrite PR, which left their order in the index list ambiguous. This bumps Post 2 ("The Business") to 2026-05-16 so it sorts after Post 1 ("The Need").

## Changes

- `thoughts.evaluating-stocks-2-the-business.mdx` frontmatter date: 2026-05-15 → 2026-05-16

## Notes

- One-line frontmatter fix, no content or redirect changes.