### PR TITLE
📝 thoughts: rebalance Post 2 to method-first (FICO to a touch)

### DIFF
--- a/app/routes/thoughts.evaluating-stocks-2-the-business.mdx
+++ b/app/routes/thoughts.evaluating-stocks-2-the-business.mdx
@@ -44,19 +44,19 @@ One deep-dive per player before I write anything down, then quarterly observatio
 
 ## The moat
 
-A moat, in my notes, is a set of named advantages, each written as prose with a primary source behind it. There are ten types I work with (brand, switching costs, network effects, scale, pricing power, regulatory protection, and a handful more), and an element either earns its place with evidence or it doesn't. No 1-to-5 rating. What each one carries instead is a direction: stable, eroding, or strengthening, so the picture moves as the world does.
+A moat, in my notes, is a set of named advantages, each written as prose with a primary source behind it. There are ten types I work with (brand, switching costs, network effects, scale, pricing power, regulatory protection, and a handful more), and an element either earns its place with evidence or it doesn't. What each one carries is a direction: stable, eroding, or strengthening, so the picture moves as the world does.
 
 For FICO the most load-bearing advantage is regulatory: federal rules effectively require its score across large parts of mortgage lending. That used to be exclusive, and a 2026 ruling cracked the door open to a competitor, so I tag it eroding and watch it harder than the rest. Brand, switching costs, and pricing power read as mostly stable. The direction tags are where the attention goes, not the labels.
 
 ## Does it dominate on all three legs
 
-A company can lead on revenue and still be weak on profit, or grow fast and keep none of the cash. So I check three legs on their own: revenue, profit, and growth. Each gets a plain pass or fail with evidence behind it. I don't average them into one number, because a strong leg shouldn't be allowed to paper over a failing one.
+A company can lead on revenue and still be weak on profit, or grow fast and keep none of the cash. So I check three legs on their own: revenue, profit, and growth. Each gets a plain pass or fail with evidence behind it. I keep them separate on purpose, because a strong leg shouldn't be allowed to paper over a failing one.
 
 FICO passes all three today: it leads its market, the economics are genuinely high-margin, and it's still growing. The verdict matters less than the habit of looking at each leg separately before nodding along.
 
 ## What management did with the cash
 
-Between the business and the numbers sits management. I keep ten years of major capital decisions, each logged with what it was, roughly how much, and whether it created value, destroyed it, or did neither. No score. Just the call and what came of it.
+Between the business and the numbers sits management. I keep ten years of major capital decisions, each logged with what it was, roughly how much, and whether it created value, destroyed it, or did neither. Just the call and what came of it.
 
 Reading them in sequence is how I tell whether management has been a friend or a tax over time. For FICO the recent record is mixed: some sharp value-creating moves alongside buybacks at rich prices I've tagged neutral-for-now, with a note to revisit. Keeping the judgment attached to its date is what makes the record useful five years later.
 
@@ -80,7 +80,7 @@ For FICO they're written as specific, observable combinations, the kind of thing
 
 ## The numbers come last
 
-Only here do I look hard at the financials, and only to confirm what the rest already said. They're facts the company already produced, pulled from its 10-K and 10-Q filings and verifiable against EDGAR. They get calculated from the line items, not assigned. If the business and the moat read like a fortress and the returns on capital came back mediocre, something in my read would be wrong. For FICO, the numbers and the story agree:
+Only here do I look hard at the financials, and only to confirm what the rest already said. They're facts the company already produced, pulled from its 10-K and 10-Q filings and verifiable against EDGAR. They get calculated straight from the line items. If the business and the moat read like a fortress and the returns on capital came back mediocre, something in my read would be wrong. For FICO, the numbers and the story agree:
 
 | Metric | TTM |
 |---|---|
@@ -107,7 +107,7 @@ When I do enter, sizing lives in three qualitative buckets:
 - **Normal (5-10%).** Solid business, solid thesis, regular size.
 - **Tracking (2-5%).** Exposure I want with relevant uncertainty, or where I'm still learning the operational shape.
 
-The ranges are percentages of total patrimony, not of any sub-bucket. No matrix. No formula. I decide the bucket against the same judgment factors above.
+The ranges are percentages of total patrimony, not of any sub-bucket. I pick the bucket by judgment, against the same factors above.
 
 A thesis can carry more than one qualified player at the same time, and the qualified set can shift as the world moves. Under Credit Scoring, FICO is the obvious candidate today, and Equifax sits on the same roster capturing a different slice of the need (consumer-credit data, distribution to lenders, a co-owner stake in VantageScore). If FICO's regulatory floor erodes and Equifax's distribution share strengthens, either or both could qualify at a given moment. The discipline says "this is worth capital" for any that pass. Which one, how much, and when stay calls I make against the factors above.
 

--- a/app/routes/thoughts.evaluating-stocks-2-the-business.mdx
+++ b/app/routes/thoughts.evaluating-stocks-2-the-business.mdx
@@ -28,131 +28,72 @@ A player on a roster is a candidate, not a position. Whether to commit capital i
 
 For each candidate I keep five pieces. What it does. Where its moat is. Whether it dominates on revenue, profit, and growth. What would break it, and the pre-mortem that maps to those. What would make me leave. The numbers come last, as confirmation.
 
-I'll walk through them on FICO. What follows is some of what I keep, not all of it. The full record has more under each piece (more moat elements, more falsifiers, more capital allocation decisions, more pre-mortem causes). The shape is the same.
+I'll use FICO, the example from the last post, as the illustration. The point isn't FICO. It's the shape of the read. What follows is some of what I keep, not all of it.
 
-## What FICO sells
+## What it does
 
-Two segments, per FICO's 10-K Item 1 (business description) and the segment notes in the financial statements.
+Before anything else I make sure I can say, in one sentence, what the company sells and where the money comes from. For FICO: it licenses the credit-score algorithm to lenders, mostly through the three credit bureaus, and that licensing is the slice anchored to the thesis. A separate software business rides alongside but isn't the core. That's enough to start.
 
-- **Scores.** Licenses the FICO score, the algorithm itself, distributed mostly through the three credit bureaus to lenders. Roughly 90% of US lenders use FICO somewhere in their credit decisioning (per Sen. Hawley's October 2025 letter to the CFPB). Within Scores, mortgage is about 72% of B2B Scores revenue. That's the part most directly anchored to the thesis.
-- **Software.** Sells decision-management platforms used by banks, insurers, and retailers. The diversification line. Its only meaningful growth sub-line is Platform, up 33% in FY25. The rest of Software is flat to declining.
+## The deep-dive behind it
 
-Scores is the dominant engine. FICO sits on the roster as a candidate today. Cleared on exclusions. Trajectory tagged "risks emerging."
+That one-sentence summary is the easy part. None of the pieces that follow come that cheaply. Behind each is a long-form deep-dive: years of filings, earnings calls, regulator pages, primary sources, a few thousand words of notes nobody else reads. The structured pieces are what that reading distills to.
 
-One thing worth knowing first. In October 2025 FICO launched **MDLP** (Mortgage Direct License Program), which lets FICO license the score algorithm directly to mortgage-report intermediaries instead of routing through the three bureaus. It runs today for non-GSE lender programs but not yet for Fannie- and Freddie-bound mortgages (about 70% of US mortgage origination). GSE-channel approval is still pending, and Pulte controls that door. That's why a lot of the regulatory pressure below points at MDLP.
+It matters because the moves that decide an investment rarely show up in a single data point. They show up when the pieces sit together. On FICO, reading across a few years surfaced a deliberate pricing-and-distribution play that no single filing called a strategy, but that plainly was one once laid side by side. That pattern is the kind of thing the deep-dive exists to catch.
 
-## The deep-dive
-
-Behind every piece I keep there's a long-form deep-dive. For FICO that meant five years of 10-Ks (Item 1, Item 1A, Item 7, segment notes), the last eight earnings transcripts, the recent proxy statements, the FHFA approved-model history, Sen. Hawley's October 2025 letter to the CFPB, the eCFR pages for the four legal anchors, and trade press around the April 2026 GSE ruling. A few thousand words of notes that nobody else reads, sitting in a long-form file separate from the thesis itself.
-
-The work matters because structural moves only show up when the pieces sit together. On FICO, the deep-dive surfaced a pincer: between 2022 and 2026, the company raised wholesale pricing roughly 1500% on the bureau channel, launched MDLP to bypass the bureaus, and then priced a new MDLP tier that matched the FHFA's $0.99 demand at the headline while preserving per-funded-loan economics. None of those three facts is a moat element on its own. Together they're one move in three pieces, and the deep-dive is where they got seen that way.
-
-The pattern is one deep-dive per player before writing anything down, then quarterly observations and an annual deep review against the same notes as the years go on.
+One deep-dive per player before I write anything down, then quarterly observations and an annual review keep it current.
 
 ## The moat
 
-A moat is a set of named pieces, one or many, each with prose and a primary source. There are ten types I work with, and only those ten: brand, switching cost, network effect, scale economies, process power, intangibles, pricing power, cornered resource (regulatory), cornered resource (structural), reinvestment moat. Most of the evidence sits in 10-K Item 1 (business description) and Item 1A (risk factors), with regulatory anchors verifiable in the eCFR or Federal Register. Alongside each element I track a trajectory in my notes (stable, eroding, or strengthening) so the picture moves as the world does.
+A moat, in my notes, is a set of named advantages, each written as prose with a primary source behind it. There are ten types I work with (brand, switching costs, network effects, scale, pricing power, regulatory protection, and a handful more), and an element either earns its place with evidence or it doesn't. No 1-to-5 rating. What each one carries instead is a direction: stable, eroding, or strengthening, so the picture moves as the world does.
 
-Six of the ten apply meaningfully to FICO. The one most pivotal to the thesis:
+For FICO the most load-bearing advantage is regulatory: federal rules effectively require its score across large parts of mortgage lending. That used to be exclusive, and a 2026 ruling cracked the door open to a competitor, so I tag it eroding and watch it harder than the rest. Brand, switching costs, and pricing power read as mostly stable. The direction tags are where the attention goes, not the labels.
 
-- **Cornered resource (regulatory).** The four legal anchors from the previous post all require validated-score use. FICO is one of two FHFA-approved models as of April 22, 2026. Before that date FICO was the sole approved model at the GSE channel. The April 22 ruling did not remove the floor. It ended exclusivity. The regulatory moat became a regulatory floor. Trajectory: eroding.
+## Does it dominate on all three legs
 
-The other five apply too (pricing power, brand, switching costs, scale economies, process power) each with its own trajectory tag. Pricing power is stable but under pressure (the same MDLP move below). Brand and switching costs are stable. The two scale-related ones are stable to strengthening.
+A company can lead on revenue and still be weak on profit, or grow fast and keep none of the cash. So I check three legs on their own: revenue, profit, and growth. Each gets a plain pass or fail with evidence behind it. I don't average them into one number, because a strong leg shouldn't be allowed to paper over a failing one.
 
-The eroding trajectory is the one I watch most. The April 2026 GSE ruling already moved the regulatory floor from sole-approved to one of two. A further FHFA action that removes FICO from the approved set entirely is the falsifier I weigh most.
-
-## Three legs of dominance
-
-A business can dominate revenue and not profit. It can grow fast and capture none of the profit. The three-leg test asks whether the thesis-aligned segment is dominant on all three of revenue, profit, and growth. Three binary pass-or-fail verdicts, each with evidence and a primary source.
-
-For FICO under Credit Scoring:
-
-- **Revenue.** Pass. About 90% of US lender share. Mortgage Scores revenue grew 127% YoY in Q2 FY26. VS approval at the GSE channel happened in April 2026, but LOS reconfiguration cycles take 12 to 36 months, so the share is sticky in the short and medium term.
-- **Profit.** Pass. Scores segment operating margin ran around 88% in FY25 via near-zero marginal cost per score. Blended TTM operating margin 50.4%. FCF over net income at 1.19. Mortgage is 72% of B2B Scores revenue.
-- **Growth.** Pass. TTM revenue growth approximately 15% YoY. Organic. Multiple growth fronts running at once: Scores pricing capture, MDLP mortgage origination, the Software Platform sub-line, UltraFICO plus Plaid alt-data.
-
-All three pass. The dominant engine is intact today. Whether it stays intact is what the falsifiers are for.
+FICO passes all three today: it leads its market, the economics are genuinely high-margin, and it's still growing. The verdict matters less than the habit of looking at each leg separately before nodding along.
 
 ## What management did with the cash
 
-Capital allocation sits between structure and numbers in the read order. The structure says what kind of business this is. The numbers say whether it produced cash. Management is the part in the middle that decides whether the cash, once generated, does useful work or quiet damage.
+Between the business and the numbers sits management. I keep ten years of major capital decisions, each logged with what it was, roughly how much, and whether it created value, destroyed it, or did neither. No score. Just the call and what came of it.
 
-I keep a record of the last ten years of major decisions. For each one: the year, what the decision was, the rough amount, whether it created, destroyed, or stayed neutral for the business, and a short note. No score. Just the call and what it did.
-
-For FICO, the one that stands out most across the last few years:
-
-- **MDLP launch, October 2025.** Going-direct counter-move that licenses the algorithm direct to tri-merge resellers, bypassing the bureaus as pass-through middleman. 55 lenders and $495B annual origination capacity signed in six months. Q2 FY26 mortgage Scores revenue grew 127% YoY. Created value. The move the deep-dive flagged as part of the pincer.
-
-More on the list: aggressive price increases on Scores wholesale ($0.60 to $10 between 2018 and 2025, tagged created but now contested), routine buybacks at full multiples in 2024-2025 (tagged neutral with a note that they may look worse later if FY26 stock, down roughly 43% year to date, keeps compressing), and the Software Platform investment (tagged tbd).
-
-Reading the decisions in sequence is how I tell whether management has been a friend or a tax over time. The format preserves the thinking with the date attached, which is what makes the record useful five years from now when I revisit the call.
+Reading them in sequence is how I tell whether management has been a friend or a tax over time. For FICO the recent record is mixed: some sharp value-creating moves alongside buybacks at rich prices I've tagged neutral-for-now, with a note to revisit. Keeping the judgment attached to its date is what makes the record useful five years later.
 
 ## What would kill it
 
-The thesis has falsifiers about the need. The player has falsifiers about whether this company can capture it. Same shape, plus a probability tier (low, medium, high). A thesis-layer falsifier kills the need itself. A player-layer falsifier kills only this company's ability to capture it. The thesis can stay alive while a player on its roster falls off.
+The thesis has falsifiers about the need. Each player gets its own falsifiers about whether this particular company can keep capturing it: a concrete event, a mechanism, an observable signal, a date, a primary source, plus a rough probability. A player falsifier firing doesn't kill the thesis. It just knocks this company off it.
 
-The most material of the ones I keep for FICO is PF7:
+For FICO I keep several, each pointing at a different way the capture could break: a regulator stripping its required status, a forced price cut, a competitor finally taking share, an enforcement action. Writing them down in advance is the discipline. The bad news gets a name and a threshold before it arrives, instead of being explained away when it does.
 
-**PF7: FHFA caps MDLP at $0.99 per score and bans the per-funded-loan tail.**
+## The pre-mortem ties to the falsifiers
 
-- **Mechanism.** Pulte issues a Selling Guide bulletin or Federal Register notice capping MDLP at $0.99 per score for GSE acceptance, banning any per-funded-loan fee on top. The MDLP pricing strategy collapses to a pure $0.99 per score, killing the $65 tail that preserved the real per-funded-loan economics.
-- **Observable signal.** A Selling Guide bulletin or Federal Register notice with that specific cap.
-- **Horizon.** 2027-12-31.
-- **Probability.** Medium. Pulte has been signaling continued pressure ("still not happy") and the funded-loan tail is the obvious next pressure point.
+Before deploying capital I write a pre-mortem: three to five ways the position fails over five years, ranked by how likely I think each is. The rule I hold myself to is that every cause has to map to one of the falsifiers. If a failure I can imagine maps to nothing, either I'm missing a falsifier and I add it, or the cause is too vague and I sharpen it until it points at something I could actually observe.
 
-Six more falsifiers run the same shape, each pointing at a different failure path: the FHFA removing FICO from the approved set entirely, FICO cutting wholesale prices voluntarily under political pressure, FICO 10T adoption stalling at top mortgage lenders, the three-bureau distribution channel concentrating further, the Software diversification line turning over, and DOJ/SEC/FTC enforcement landing. None of them, on its own, kills the Credit Scoring thesis. The thesis is broader than any one player.
-
-## Pre-mortem maps to falsifier
-
-The pre-mortem is where the two layers connect in practice.
-
-I write a pre-mortem before deploying capital. Three to five causes, ranked by how likely I think each is, describing how the position fails in five years. Each cause has a description, a mechanism, and a mapped falsifier.
-
-The mapping is enforced. A cause that doesn't map to an existing falsifier is either a gap in the falsifier set or a vague cause. If it's the first, I add the falsifier. If it's the second, I sharpen the cause until it points at something observable. Unmapped causes don't make it into the pre-mortem.
-
-For FICO, the highest-likelihood cause I keep:
-
-- **Cause 1.** FHFA-driven pricing cut compounds. Pulte's $0.99 demand becomes a binding regulatory action by 2027-2028. FICO cuts 30 to 50% off wholesale price in a negotiated GSE deal. Scores revenue compresses 25 to 30%. Mapped to **PF1**.
-
-Two more causes follow the same shape, one covering VS 4.0 lender capture accelerating (mapped to PF5) and one covering the Hawley investigation escalating to formal SEC or DOJ enforcement (mapped to PF6). The pre-mortem isn't speculation. It's tied to events I can observe, dated, and sourced.
-
-The discipline runs the other way too. When I review the player annually, I take each cause and ask whether its mapped falsifier has moved closer or further. The pre-mortem isn't a one-time exercise. It's a check I keep running over time.
+For FICO the top cause maps to its top falsifier: regulatory pressure forcing a price concession. The mapping runs both ways over time. Each annual review I take the falsifiers and ask whether the failure they describe has moved closer. The pre-mortem isn't a one-time exercise, it's a check I keep running.
 
 ## What would make me leave
 
-Exit criteria sit alongside falsifiers but do a different job. A falsifier degrades conviction. An exit criterion is an observable trigger that takes me out of the position without re-evaluation.
+Exit criteria sit next to the falsifiers but do a different job. A falsifier lowers my conviction. An exit criterion is a mechanical trigger: if it fires, I'm out, with no re-litigating it in the moment. The point is to make the decision now, calmly, instead of later when the position is moving and I'm tempted to talk myself out of it.
 
-For FICO, the cleanest one:
+For FICO they're written as specific, observable combinations, the kind of thing I can't argue my way around when it actually happens.
 
-- **Compound firing.** PF1 fires (FICO removed from approved-model set) AND FICO discloses an FY revenue guide cut greater than 10% in the same reporting window.
+## The numbers come last
 
-Two more in the same shape: the three-bureau aggregate share crossing 65% of FICO revenue while VS takes more than 25% of GSE mortgage origination, and the Hawley investigation escalating to formal SEC or DOJ enforcement (or a securities class action). Each one is mechanical. If it fires, I leave. The decision is made now, when nothing is on the line, instead of in the moment when something is.
-
-## The numbers
-
-Numbers come last. They're facts the company already produced, derived from the financial statements in 10-K (annual) and 10-Q (quarterly) filings, verifiable against EDGAR. They get calculated from the line items, not assigned. They confirm the moat and three-leg reads. They don't generate them.
-
-From the snapshot pulled 2026-05-15:
+Only here do I look hard at the financials, and only to confirm what the rest already said. They're facts the company already produced, pulled from its 10-K and 10-Q filings and verifiable against EDGAR. They get calculated from the line items, not assigned. If the business and the moat read like a fortress and the returns on capital came back mediocre, something in my read would be wrong. For FICO, the numbers and the story agree:
 
 | Metric | TTM |
 |---|---|
 | Revenue | $2.26B |
-| Net income | $759.6M |
-| Free cash flow | $900.9M |
-| FCF / Net income | 1.19 |
 | Return on invested capital | 68.1% |
 | Gross margin | 84.2% |
 | Operating margin | 50.4% |
-| Net margin | 33.7% |
+| FCF / Net income | 1.19 |
 | Net debt / EBITDA | 3.01 |
 
-A 68.1% ROIC is what the income statement and the balance sheet produce when divided. If the moat read said cornered resource plus switching cost plus pricing power and ROIC came in at 4%, something would be off in one or the other. With FICO, the layers agree.
+I don't forecast these forward, and I don't lean on price targets, mine or anyone's. Every projection bets on growth I can't verify, and that bet quietly becomes the thing I own instead of the business. What the numbers do tell me is whether today's price looks rich, fair, or cheap against the business behind it. That's one input to the enter-wait-skip call, not the answer. A good business at the wrong price is still a bad call.
 
-I don't project future numbers, and I don't lean on price targets (mine or anyone else's). Every projection assumes growth I can't verify, and that assumption is what I'd be betting on rather than the business itself. What gives me conviction is the business, not a model of where the price could go.
-
-What the numbers do help me read is whether the price today looks expensive, cheap, or fair against the business producing them. That's one input to the enter, wait, or skip judgment, not the answer. A good business at the wrong price is still a bad call. A good business at a fair price is what I'm looking for.
-
-One diagnostic I do run is an accrual check, which flags when reported earnings diverge from cash flow over multiple periods. Diagnostic, not a gate. I run it when something in the moat-vs-numbers read smells off.
+If the numbers and the story ever disagree, I have a couple of diagnostics to find out which one is lying: a reverse-DCF read of what today's price implies, and an accrual check for when reported earnings drift from actual cash. Flashlights, not gates.
 
 ## After qualification
 

--- a/app/routes/thoughts.evaluating-stocks-2-the-business.mdx
+++ b/app/routes/thoughts.evaluating-stocks-2-the-business.mdx
@@ -40,7 +40,7 @@ That one-sentence summary is the easy part. None of the pieces that follow come 
 
 It matters because the moves that decide an investment rarely show up in a single data point. They show up when the pieces sit together. On FICO, reading across a few years surfaced a deliberate pricing-and-distribution play that no single filing called a strategy, but that plainly was one once laid side by side. That pattern is the kind of thing the deep-dive exists to catch.
 
-One deep-dive per player before I write anything down, then quarterly observations and an annual review keep it current.
+One deep-dive per player before I write anything down, then quarterly and annual reviews keep it current.
 
 ## The moat
 
@@ -70,7 +70,7 @@ For FICO I keep several, each pointing at a different way the capture could brea
 
 Before deploying capital I write a pre-mortem: three to five ways the position fails over five years, ranked by how likely I think each is. The rule I hold myself to is that every cause has to map to one of the falsifiers. If a failure I can imagine maps to nothing, either I'm missing a falsifier and I add it, or the cause is too vague and I sharpen it until it points at something I could actually observe.
 
-For FICO the top cause maps to its top falsifier: regulatory pressure forcing a price concession. The mapping runs both ways over time. Each annual review I take the falsifiers and ask whether the failure they describe has moved closer. The pre-mortem isn't a one-time exercise, it's a check I keep running.
+For FICO the top cause maps to its top falsifier: regulatory pressure forcing a price concession. The mapping runs both ways over time. At each review, quarterly and annual, I take the falsifiers and ask whether the failure they describe has moved closer. The pre-mortem isn't a one-time exercise, it's a check I keep running.
 
 ## What would make me leave
 
@@ -80,7 +80,14 @@ For FICO they're written as specific, observable combinations, the kind of thing
 
 ## The numbers come last
 
-Only here do I look hard at the financials, and only to confirm what the rest already said. They're facts the company already produced, pulled from its 10-K and 10-Q filings and verifiable against EDGAR. They get calculated straight from the line items. If the business and the moat read like a fortress and the returns on capital came back mediocre, something in my read would be wrong. For FICO, the numbers and the story agree:
+Only here do I look hard at the financials, and only to confirm what the rest already said. They're facts the company already produced, pulled from its 10-K and 10-Q filings and verifiable against EDGAR. They get calculated straight from the line items. If the business and the moat read like a fortress and the returns on capital came back mediocre, something in my read would be wrong. For FICO, the numbers and the story agree. In plain terms:
+
+- **It keeps an unusually high share of what it sells as profit** (operating margin).
+- **It turns more than all of its reported profit into actual cash** (free cash flow against net income).
+- **It earns extraordinary returns on the money it puts to work** (return on invested capital), near 70% where even strong businesses usually sit under 20%.
+- **It carries a moderate amount of debt against its earnings** (net debt to EBITDA).
+
+The underlying figures, from the snapshot pulled 2026-05-15:
 
 | Metric | TTM |
 |---|---|
@@ -88,7 +95,7 @@ Only here do I look hard at the financials, and only to confirm what the rest al
 | Return on invested capital | 68.1% |
 | Gross margin | 84.2% |
 | Operating margin | 50.4% |
-| FCF / Net income | 1.19 |
+| Free cash flow / Net income | 1.19 |
 | Net debt / EBITDA | 3.01 |
 
 I don't forecast these forward, and I don't lean on price targets, mine or anyone's. Every projection bets on growth I can't verify, and that bet quietly becomes the thing I own instead of the business. What the numbers do tell me is whether today's price looks rich, fair, or cheap against the business behind it. That's one input to the enter-wait-skip call, not the answer. A good business at the wrong price is still a bad call.
@@ -107,7 +114,7 @@ When I do enter, sizing lives in three qualitative buckets:
 - **Normal (5-10%).** Solid business, solid thesis, regular size.
 - **Tracking (2-5%).** Exposure I want with relevant uncertainty, or where I'm still learning the operational shape.
 
-The ranges are percentages of total patrimony, not of any sub-bucket. I pick the bucket by judgment, against the same factors above.
+The ranges are percentages of total net worth, not of any sub-bucket. I pick the bucket by judgment, against the same factors above.
 
 A thesis can carry more than one qualified player at the same time, and the qualified set can shift as the world moves. Under Credit Scoring, FICO is the obvious candidate today, and Equifax sits on the same roster capturing a different slice of the need (consumer-credit data, distribution to lenders, a co-owner stake in VantageScore). If FICO's regulatory floor erodes and Equifax's distribution share strengthens, either or both could qualify at a given moment. The discipline says "this is worth capital" for any that pass. Which one, how much, and when stay calls I make against the factors above.
 

--- a/app/routes/thoughts.evaluating-stocks-2-the-business.mdx
+++ b/app/routes/thoughts.evaluating-stocks-2-the-business.mdx
@@ -26,7 +26,18 @@ This is the post about the names.
 
 A player on a roster is a candidate, not a position. Whether to commit capital is its own question. What I keep for each candidate makes sure that question gets answered against evidence, not impulse.
 
-For each candidate I keep five pieces. What it does. Where its moat is. Whether it dominates on revenue, profit, and growth. What would break it, and the pre-mortem that maps to those. What would make me leave. The numbers come last, as confirmation.
+For each candidate I keep the same set of pieces, each defined the same way every time:
+
+- **What it does.** The business in a sentence.
+- **The moat.** Its durable advantages, each evidenced and given a direction.
+- **The three legs.** Whether it dominates on revenue, profit, and growth.
+- **Falsifiers.** Specific events that would break its hold on the need.
+- **Watch signals.** Softer signals I track between falsifiers, defined just as tightly: what I watch, what trips it, how often, and the source.
+- **The pre-mortem.** Ranked ways it fails, each one tied to a falsifier.
+- **Exit criteria.** Mechanical triggers to leave.
+- **The numbers.** The financials, last, as confirmation.
+
+Two more only matter once I act: what management did with the cash, and the entry context I freeze if I buy.
 
 I'll use FICO, the example from the last post, as the illustration. The point isn't FICO. It's the shape of the read. What follows is some of what I keep, not all of it.
 
@@ -65,6 +76,8 @@ Reading them in sequence is how I tell whether management has been a friend or a
 The thesis has falsifiers about the need. Each player gets its own falsifiers about whether this particular company can keep capturing it: a concrete event, a mechanism, an observable signal, a date, a primary source, plus a rough probability. A player falsifier firing doesn't kill the thesis. It just knocks this company off it.
 
 For FICO I keep several, each pointing at a different way the capture could break: a regulator stripping its required status, a forced price cut, a competitor finally taking share, an enforcement action. Writing them down in advance is the discipline. The bad news gets a name and a threshold before it arrives, instead of being explained away when it does.
+
+Watch signals are the falsifiers' lighter siblings, written with the same parts: what I watch, what would trip it, how often I check, and the source. The difference is the job. A falsifier breaks the case when it fires. A watch signal only moves my confidence and points to where the next falsifier might form. For FICO, one is its distribution growing more concentrated in a few channels, worth tracking long before it would ever break anything.
 
 ## The pre-mortem ties to the falsifiers
 


### PR DESCRIPTION
## What

Rebalance "The Business" so it teaches the evaluation method, not FICO. FICO stays as a light illustration (it's the example carried from Post 1), but the FICO-tutorial depth is gone.

## Changes

- Each section leads with the method, then one crisp FICO touch
- Cut: segment percentages, MDLP mechanics, GSE/Pulte politics, PF7 specifics, per-leg numbers
- Compressed the MDLP pincer to a two-sentence illustration of why a deep-dive matters
- Trimmed the numbers table to the confirmation-layer essentials
- Section titles now mirror the five pieces named in the opener
- Net: ~85 lines removed, ~26 added

## Notes

Post 1 ("The Need") was reviewed and left unchanged. It's already method-first, and its one denser section is load-bearing as written. This PR touches Post 2 only.