### PR TITLE
📝 quotes: add nine (Zen / no-self, Watts, Epicurus)

### DIFF
--- a/app/db/quotes.ts
+++ b/app/db/quotes.ts
@@ -14,4 +14,6 @@ export const quotes: string[] = [
   "\u201CYou exist as an idea in your mind.\u201D - Shunryu Suzuki",
   "\u201CTo study the self is to forget the self.\u201D - D\u014Dgen",
   "\u201CWe are here to awaken from our illusion of separateness.\u201D - Thich Nhat Hanh",
+  "\u201CSitting quietly, doing nothing, spring comes, and the grass grows by itself.\u201D - Zen proverb",
+  "\u201CWhen walking, walk. When eating, eat.\u201D - Zen proverb",
 ];

--- a/app/db/quotes.ts
+++ b/app/db/quotes.ts
@@ -11,4 +11,7 @@ export const quotes: string[] = [
   "\u201CThe obstacle is the path.\u201D - Zen proverb",
   "\u201CMuddy water is best cleared by leaving it alone.\u201D - Alan Watts",
   "\u201CNot what we have but what we enjoy, constitutes our abundance.\u201D - Epicurus",
+  "\u201CYou exist as an idea in your mind.\u201D - Shunryu Suzuki",
+  "\u201CTo study the self is to forget the self.\u201D - D\u014Dgen",
+  "\u201CWe are here to awaken from our illusion of separateness.\u201D - Thich Nhat Hanh",
 ];

--- a/app/db/quotes.ts
+++ b/app/db/quotes.ts
@@ -7,4 +7,8 @@ export const quotes: string[] = [
   "\u201CTrying to define yourself is like trying to bite your own teeth.\u201D - Alan Watts",
   "\u201CIn Zen, we don\u2019t find the answers. We lose the questions.\u201D - Zen proverb",
   "\u201CThings are as they are. Looking out into the universe at night, we make no comparisons between right and wrong stars.\u201D - Alan Watts",
+  "\u201CBefore enlightenment, chop wood, carry water. After enlightenment, chop wood, carry water.\u201D - Zen proverb",
+  "\u201CThe obstacle is the path.\u201D - Zen proverb",
+  "\u201CMuddy water is best cleared by leaving it alone.\u201D - Alan Watts",
+  "\u201CNot what we have but what we enjoy, constitutes our abundance.\u201D - Epicurus",
 ];


### PR DESCRIPTION
Adds nine quotes to the footer rotation, in the same philosophical lineage as the existing set (Taoism, Zen, Epicureanism, Watts). Reinforces the Zen / no-self (anattā) strand, previously the thinnest. Set grows 8 → 17.

**Zen / no-self**
- **"You exist as an idea in your mind."** — Shunryu Suzuki
- **"To study the self is to forget the self."** — Dōgen (*Genjōkōan*)
- **"We are here to awaken from our illusion of separateness."** — Thich Nhat Hanh

**Zen proverbs**
- **"Before enlightenment, chop wood, carry water. After enlightenment, chop wood, carry water."**
- **"The obstacle is the path."**
- **"Sitting quietly, doing nothing, spring comes, and the grass grows by itself."** (*Zenrin Kushu*)
- **"When walking, walk. When eating, eat."** (rooted in Yunmen)

**Alan Watts**
- **"Muddy water is best cleared by leaving it alone."** (*The Way of Zen*)

**Epicureanism**
- **"Not what we have but what we enjoy, constitutes our abundance."** — Epicurus

All attributions checked; quotes with soft or motivational-culture sourcing were left out. No code changes — data only.