### PR TITLE
🐳 fix(docker): bump Node 20.15 → 22.20 to fix vite 8 deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.15.0
+ARG NODE_VERSION=22.20.0
 FROM node:${NODE_VERSION}-slim as base
 
 LABEL fly_launch_runtime="Remix"


### PR DESCRIPTION
## Problem
Deploy broke after merging vite 8 (#144). The Fly Docker build fails during `npm run build`:

```
node_modules/rolldown/dist/shared/binding-*.mjs ... code: 'MODULE_NOT_FOUND'
```

## Root cause
vite 8 replaced rollup with **rolldown**, which ships its native binary as platform-specific `optionalDependencies` (`@rolldown/binding-linux-x64-gnu`, etc.). The Dockerfile ran on **Node 20.15.0 → npm 10.7.0**, which has the well-known cross-platform optional-deps bug: when `package-lock.json` is generated on macOS, `npm ci` on linux **silently skips the linux native binding**, so the bundler can't load at build time.

## Fix
Bump `NODE_VERSION` to **22.20.0** (npm 10.9.3), which installs the native binding correctly. Bonus: matches local dev Node and satisfies `engines: >=20`.

## Verification (reproduced + fixed locally in Docker)
Empirically tested `linux/amd64` builds:

| Node / npm | rolldown native binding | `require('rolldown')` |
|---|---|---|
| 20.15.0 / 10.7.0 (before) | ❌ not installed | ❌ crash |
| 20.15.0 + `--os/--cpu` flags | ❌ not installed | ❌ crash |
| **22.20.0 / 10.9.3 (this PR)** | ✅ installed | ✅ ROLLDOWN_OK |

Full `docker build --platform linux/amd64`: **build ✓**, container boots (`react-router-serve`) ✓, homepage **HTTP 200** ✓.