### PR TITLE
📝 copy: update title lead engineer → CTO

### DIFF
--- a/app/components/now.tsx
+++ b/app/components/now.tsx
@@ -93,7 +93,7 @@ const Now = () => {
           Now
         </h2>
         <p className="text-sm leading-7">
-          By day, I work as a Lead Engineer at{" "}
+          By day, I work as CTO at{" "}
           <a
             className="link-underline"
             href="https://www.summit-mgmt.mx"

--- a/app/routes/thoughts.evaluating-stocks-1-the-need.mdx
+++ b/app/routes/thoughts.evaluating-stocks-1-the-need.mdx
@@ -20,7 +20,7 @@ export const meta = () => [
   <span>{formatDate(frontmatter.date)}</span>
 </time>
 
-Since mid-2024 I've worked as a lead engineer at Summit Management, a hedge fund. My job is the fund's system: data pipelines, returns and performance, the infrastructure behind investment decisions.
+Since mid-2024 I've worked as CTO at Summit Management, a hedge fund. My job is the fund's system: data pipelines, returns and performance, the infrastructure behind investment decisions.
 
 Along the way I picked up the basics. P/E ratios, ROIC, debt-to-equity, revenue growth. Enough to follow the conversation, not enough to call myself an analyst. At some point I asked myself a simple question. If I were to invest my own money, what would I actually look for?
 


### PR DESCRIPTION
Update role title from Lead Engineer to CTO in two spots:

- `now.tsx` — Now section
- `thoughts.evaluating-stocks-1-the-need.mdx` — post intro