### PR TITLE
✨ feat(now-watching): Letterboxd-style star ratings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 
 # Superpowers specs and plans
 docs/superpowers/
+# Trakt export + Letterboxd migration (personal data, do not commit)
+trakt-export-ocordova/
+letterboxd-import.csv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,10 @@ Personal site for Óscar Córdova. React Router + Tailwind CSS + shadcn/ui (zinc
 - `npm run typecheck` — Type check
 - `npm run lint` — Lint
 
+## Git & PRs
+
+- Do not add the Claude session link or `Claude-Session:` trailer to commit messages or pull request descriptions.
+
 ## Design Context
 
 ### Users

--- a/app/actions/now-watching.server.ts
+++ b/app/actions/now-watching.server.ts
@@ -88,8 +88,8 @@ async function fetchNowWatching(): Promise<NowWatching> {
       date: new Date(watchedDate),
       poster,
       url: link ?? LETTERBOXD_PROFILE,
-      // Letterboxd rates 0.5–5 stars; the UI expects a 1–10 scale.
-      rating: memberRating ? Math.round(Number(memberRating) * 2) : undefined,
+      // Letterboxd rating: 0.5–5 stars, in half-star steps. Rendered as stars.
+      rating: memberRating ? Number(memberRating) : undefined,
     };
   }
 

--- a/app/components/now.tsx
+++ b/app/components/now.tsx
@@ -1,18 +1,12 @@
 import { useNowListening, useNowReading, useNowWatching } from "~/lib/hooks";
 import { Skeleton } from "./ui/skeleton";
 
-const ratingLabels: Record<number, string> = {
-  1: "Weak Sauce",
-  2: "Terrible",
-  3: "Bad",
-  4: "Poor",
-  5: "Meh",
-  6: "Fair",
-  7: "Good",
-  8: "Great",
-  9: "Superb",
-  10: "Totally Ninja!",
-};
+// Letterboxd-style stars from a 0.5–5 rating, e.g. 3.5 -> "★★★½".
+function starRating(rating: number): string {
+  const full = Math.floor(rating);
+  const half = rating - full >= 0.5;
+  return "★".repeat(full) + (half ? "½" : "");
+}
 
 function shortTimeAgo(date: Date): string {
   const diff = Date.now() - date.getTime();
@@ -213,8 +207,8 @@ const Now = () => {
                 <>
                   {movie.rating && (
                     <>
-                      <span className="flex-shrink-0">
-                        ★ {movie.rating} {ratingLabels[movie.rating]}
+                      <span className="flex-shrink-0" aria-label={`${movie.rating} out of 5 stars`}>
+                        {starRating(movie.rating)}
                       </span>
                       <span className="flex-shrink-0">&middot;</span>
                     </>


### PR DESCRIPTION
## What

Swap the rating display in the "Now / Watching" row from the old Trakt-era numeric + label (`★ 8 Totally Ninja!`) to plain Letterboxd-style stars (`★★★★½`).

The 1–10 labels ("Weak Sauce" … "Totally Ninja!") no longer make sense now that ratings come from Letterboxd's 0.5–5 half-star scale.

- `now-watching.server.ts`: keep the raw Letterboxd rating (0.5–5) instead of rescaling `×2` to 1–10
- `now.tsx`: drop `ratingLabels`, render `Math.floor` full stars + a `½` when the half-step is set; add an `aria-label` for screen readers
- `.gitignore`: exclude the local Trakt export dir and the generated Letterboxd CSV (personal data, never committed)
- `CLAUDE.md`: note to omit the Claude session trailer in commits/PRs

## Render check

```
5   -> ★★★★★
4.5 -> ★★★★½
3.5 -> ★★★½
1   -> ★
0.5 -> ½
```

Unrated films show no stars (unchanged).