### PR TITLE
🐛 fix(now-reading): fall back to last finished book + show time-ago

### DIFF
--- a/app/actions/now-reading.server.ts
+++ b/app/actions/now-reading.server.ts
@@ -10,9 +10,11 @@ export interface NowReading {
   cover: string;
   url: string;
   author: string;
+  date: string;
 }
 
 interface LiteralBook {
+  id: string;
   slug: string;
   title: string;
   subtitle: string;
@@ -21,6 +23,24 @@ interface LiteralBook {
 }
 
 type ReadingStatus = "IS_READING" | "FINISHED";
+
+async function literalQuery<T>(query: string, variables: object): Promise<T> {
+  const response = await fetch(LITERAL_API, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${LITERAL_TOKEN}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const { data, errors } = await response.json();
+  if (errors) {
+    console.error("[literal] query errors:", errors);
+    throw new Error("Failed to fetch now reading data");
+  }
+  return data;
+}
 
 // readingStatus is a fixed enum constant, not user input, so interpolating it
 // into the query is safe. profileId stays a bound variable.
@@ -33,6 +53,7 @@ query booksByReadingStateAndProfile($profileId: String!) {
     readingStatus: ${status}
     profileId: $profileId
   ) {
+    id
     slug
     title
     subtitle
@@ -44,25 +65,25 @@ query booksByReadingStateAndProfile($profileId: String!) {
 }`;
 }
 
-async function fetchBooks(status: ReadingStatus): Promise<LiteralBook[]> {
-  const response = await fetch(LITERAL_API, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${LITERAL_TOKEN}`,
-    },
-    body: JSON.stringify({
-      query: booksQuery(status),
-      variables: { profileId: LITERAL_PROFILE_ID },
-    }),
-  });
-
-  const { data, errors } = await response.json();
-  if (errors) {
-    console.error("[literal] query errors:", errors);
-    throw new Error("Failed to fetch now reading data");
+const READING_STATE_QUERY = `
+query readingStateByWork($bookId: String!, $profileId: String!) {
+  readingStateByWork(bookId: $bookId, profileId: $profileId) {
+    createdAt
   }
-  return data?.booksByReadingStateAndProfile ?? [];
+}`;
+
+async function fetchBooks(status: ReadingStatus): Promise<LiteralBook[]> {
+  const data = await literalQuery<{
+    booksByReadingStateAndProfile: LiteralBook[];
+  }>(booksQuery(status), { profileId: LITERAL_PROFILE_ID });
+  return data.booksByReadingStateAndProfile ?? [];
+}
+
+async function fetchReadingDate(bookId: string): Promise<string> {
+  const data = await literalQuery<{
+    readingStateByWork: { createdAt: string } | null;
+  }>(READING_STATE_QUERY, { bookId, profileId: LITERAL_PROFILE_ID });
+  return data.readingStateByWork?.createdAt ?? "";
 }
 
 async function fetchNowReading(): Promise<NowReading> {
@@ -81,6 +102,7 @@ async function fetchNowReading(): Promise<NowReading> {
     cover: book.cover,
     url: `https://literal.club/book/${book.slug}`,
     author: book.authors[0]?.name ?? "",
+    date: await fetchReadingDate(book.id),
   };
 }
 

--- a/app/actions/now-reading.server.ts
+++ b/app/actions/now-reading.server.ts
@@ -12,82 +12,76 @@ export interface NowReading {
   author: string;
 }
 
-const BOOKS_BY_READING_STATE_AND_PROFILE = `
-query booksByReadingStateAndProfile(
-  $profileId: String!
-) {
+interface LiteralBook {
+  slug: string;
+  title: string;
+  subtitle: string;
+  cover: string;
+  authors: { name: string }[];
+}
+
+type ReadingStatus = "IS_READING" | "FINISHED";
+
+// readingStatus is a fixed enum constant, not user input, so interpolating it
+// into the query is safe. profileId stays a bound variable.
+function booksQuery(status: ReadingStatus): string {
+  return `
+query booksByReadingStateAndProfile($profileId: String!) {
   booksByReadingStateAndProfile(
-    limit: 3
+    limit: 1
     offset: 0
-    readingStatus: IS_READING
+    readingStatus: ${status}
     profileId: $profileId
   ) {
-    ...BookParts # find fragments below
+    slug
+    title
+    subtitle
+    cover
+    authors {
+      name
+    }
   }
+}`;
 }
-fragment BookParts on Book {
-	id
-	slug
-	title
-	subtitle
-	description
-	isbn10
-	isbn13
-	language
-	pageCount
-	publishedDate
-	publisher
-	cover
-	authors {
-		id
-		name
-	}
-	gradientColors
-}
-`;
 
-async function fetchNowReading(): Promise<NowReading> {
-  try {
-    const response = await fetch(LITERAL_API, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${LITERAL_TOKEN}`,
-      },
-      body: JSON.stringify({
-        query: BOOKS_BY_READING_STATE_AND_PROFILE,
-        variables: {
-          profileId: LITERAL_PROFILE_ID,
-        },
-      }),
-    });
+async function fetchBooks(status: ReadingStatus): Promise<LiteralBook[]> {
+  const response = await fetch(LITERAL_API, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${LITERAL_TOKEN}`,
+    },
+    body: JSON.stringify({
+      query: booksQuery(status),
+      variables: { profileId: LITERAL_PROFILE_ID },
+    }),
+  });
 
-    const { data, errors } = await response.json();
-
-    if (errors) {
-      console.error(errors);
-      throw new Error("Failed to fetch now reading data");
-    }
-
-    const currentReading = data.booksByReadingStateAndProfile;
-
-    if (!currentReading.length) {
-      throw new Error("No books found");
-    }
-
-    const book = currentReading[0];
-    const url = `https://literal.club/book/${book.slug}`;
-    return {
-      title: book.title,
-      subtitle: book.subtitle,
-      cover: book.cover,
-      url,
-      author: book.authors[0].name,
-    };
-  } catch (error) {
-    console.error(error);
+  const { data, errors } = await response.json();
+  if (errors) {
+    console.error("[literal] query errors:", errors);
     throw new Error("Failed to fetch now reading data");
   }
+  return data?.booksByReadingStateAndProfile ?? [];
+}
+
+async function fetchNowReading(): Promise<NowReading> {
+  // Prefer a book in progress; otherwise fall back to the most recently
+  // finished one so the row is never empty between books.
+  const [reading] = await fetchBooks("IS_READING");
+  const book = reading ?? (await fetchBooks("FINISHED"))[0];
+
+  if (!book) {
+    throw new Error("No books found");
+  }
+
+  return {
+    title: book.title,
+    subtitle: book.subtitle,
+    cover: book.cover,
+    url: `https://literal.club/book/${book.slug}`,
+    author: book.authors[0]?.name ?? "",
+  };
 }
 
 export const getNowReading = (): Promise<NowReading> =>

--- a/app/components/now.tsx
+++ b/app/components/now.tsx
@@ -179,7 +179,19 @@ const Now = () => {
               ) : null
             }
             meta={
-              book ? <span className="truncate">{book.author}</span> : undefined
+              book ? (
+                <>
+                  <span className="truncate">{book.author}</span>
+                  {book.date && (
+                    <>
+                      <span className="flex-shrink-0">&middot;</span>
+                      <span className="text-muted-foreground flex-shrink-0">
+                        {shortTimeAgo(new Date(book.date))}
+                      </span>
+                    </>
+                  )}
+                </>
+              ) : undefined
             }
           />
 


### PR DESCRIPTION
## Bug

`/api/now-reading` returned **500** whenever no book was marked `IS_READING` on Literal — the list came back empty and `fetchNowReading` threw `No books found`. Between books the "Reading" row errored instead of showing anything. (This was the live 500 in prod; the Literal token/API are fine, the list was just empty.)

## Fix + feature

1. **Fallback** — query `IS_READING` first, then fall back to the most recently `FINISHED` book (Literal returns them most-recent-first; verified `One Up On Wall Street` is the latest). The row always shows the current or last-read book and only errors if the profile has no books at all.
2. **Time-ago** — the Reading row was the only one without a timestamp. `readingStateByWork(bookId, profileId)` exposes the reading state's `createdAt` with the profile token (no user auth), so we fetch it and render `Xd ago` next to the author, matching the Watching/Listening rows.

- Parametrize the books query by reading status (fixed enum, safe to interpolate); `profileId` stays a bound variable
- Add `date` to `NowReading`; render it with the shared `shortTimeAgo` helper

## Verified against the live Literal API

```
IS_READING            -> []                              (empty → falls back)
FINISHED[0]           -> One Up On Wall Street — Peter Lynch
readingStateByWork    -> createdAt 2026-08-03  ->  "5d ago"
```

Note: `createdAt` is when the reading state was set — for a finished book that's ~when it was finished (approximate if the book passed through several states). Good enough for a relative "Xd ago".