### PR TITLE
⚡️ perf(now): serve stale cache instantly, revalidate in background

### DIFF
--- a/app/actions/now-listening.server.ts
+++ b/app/actions/now-listening.server.ts
@@ -46,5 +46,5 @@ const fetchNowListening = async (): Promise<NowListening> => {
   }
 };
 
-export const getNowListening = (): Promise<NowListening> =>
-  cached("now-listening", TTL.listening, fetchNowListening);
+export const getNowListening = (opts?: { wait?: boolean }) =>
+  cached("now-listening", TTL.listening, fetchNowListening, opts);

--- a/app/actions/now-playing.server.ts
+++ b/app/actions/now-playing.server.ts
@@ -35,5 +35,5 @@ async function fetchNowPlaying(): Promise<NowPlaying> {
   };
 }
 
-export const getNowPlaying = (): Promise<NowPlaying> =>
-  cached("now-playing", TTL.playing, fetchNowPlaying);
+export const getNowPlaying = (opts?: { wait?: boolean }) =>
+  cached("now-playing", TTL.playing, fetchNowPlaying, opts);

--- a/app/actions/now-reading.server.ts
+++ b/app/actions/now-reading.server.ts
@@ -106,5 +106,5 @@ async function fetchNowReading(): Promise<NowReading> {
   };
 }
 
-export const getNowReading = (): Promise<NowReading> =>
-  cached("now-reading", TTL.reading, fetchNowReading);
+export const getNowReading = (opts?: { wait?: boolean }) =>
+  cached("now-reading", TTL.reading, fetchNowReading, opts);

--- a/app/actions/now-watching.server.ts
+++ b/app/actions/now-watching.server.ts
@@ -96,5 +96,5 @@ async function fetchNowWatching(): Promise<NowWatching> {
   throw new Error("No films found in Letterboxd feed");
 }
 
-export const getNowWatching = (): Promise<NowWatching> =>
-  cached("now-watching", TTL.watching, fetchNowWatching);
+export const getNowWatching = (opts?: { wait?: boolean }) =>
+  cached("now-watching", TTL.watching, fetchNowWatching, opts);

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -12,6 +12,20 @@ import { ServerRouter } from "react-router";
 import { isbot } from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
 
+import { getNowListening } from "~/actions/now-listening.server";
+import { getNowPlaying } from "~/actions/now-playing.server";
+import { getNowReading } from "~/actions/now-reading.server";
+import { getNowWatching } from "~/actions/now-watching.server";
+
+// Warm the now-* caches at boot so the first visitor after a deploy or
+// machine wake never waits on a third-party API.
+void Promise.allSettled([
+  getNowListening(),
+  getNowPlaying(),
+  getNowReading(),
+  getNowWatching(),
+]);
+
 const ABORT_DELAY = 5_000;
 
 export default function handleRequest(

--- a/app/lib/cache.server.test.ts
+++ b/app/lib/cache.server.test.ts
@@ -17,12 +17,12 @@ describe("cached", () => {
     const a = await cached("k", 1_000, fetcher);
     const b = await cached("k", 1_000, fetcher);
 
-    expect(a).toBe("v1");
-    expect(b).toBe("v1");
+    expect(a).toEqual({ value: "v1", stale: false });
+    expect(b).toEqual({ value: "v1", stale: false });
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
-  it("refetches after the TTL expires", async () => {
+  it("serves the stale value immediately after the TTL and revalidates in the background", async () => {
     const fetcher = vi
       .fn()
       .mockResolvedValueOnce("v1")
@@ -30,13 +30,57 @@ describe("cached", () => {
 
     await cached("k", 1_000, fetcher);
     vi.setSystemTime(Date.now() + 1_001);
-    const second = await cached("k", 1_000, fetcher);
 
-    expect(second).toBe("v2");
+    const second = await cached("k", 1_000, fetcher);
+    expect(second).toEqual({ value: "v1", stale: true });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    // let the background revalidation settle
+    await vi.runAllTimersAsync();
+
+    const third = await cached("k", 1_000, fetcher);
+    expect(third).toEqual({ value: "v2", stale: false });
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
-  it("serves the stale value when the fetcher rejects after the TTL", async () => {
+  it("waits for the fresh value when wait is set on a stale entry", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce("v1")
+      .mockResolvedValueOnce("v2");
+
+    await cached("k", 1_000, fetcher);
+    vi.setSystemTime(Date.now() + 1_001);
+
+    const fresh = await cached("k", 1_000, fetcher, { wait: true });
+
+    expect(fresh).toEqual({ value: "v2", stale: false });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps serving the stale value when background revalidation fails", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce("v1")
+      .mockRejectedValue(new Error("upstream down"));
+
+    await cached("k", 1_000, fetcher);
+    vi.setSystemTime(Date.now() + 1_001);
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const second = await cached("k", 1_000, fetcher);
+    await vi.runAllTimersAsync();
+
+    expect(second).toEqual({ value: "v1", stale: true });
+    expect(consoleError).toHaveBeenCalled();
+
+    const third = await cached("k", 1_000, fetcher);
+    await vi.runAllTimersAsync();
+    expect(third).toEqual({ value: "v1", stale: true });
+    consoleError.mockRestore();
+  });
+
+  it("falls back to the stale value when wait is set and revalidation fails", async () => {
     const fetcher = vi
       .fn()
       .mockResolvedValueOnce("v1")
@@ -46,17 +90,18 @@ describe("cached", () => {
     vi.setSystemTime(Date.now() + 1_001);
 
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    const second = await cached("k", 1_000, fetcher);
-
-    expect(second).toBe("v1");
-    expect(consoleError).toHaveBeenCalled();
+    const result = await cached("k", 1_000, fetcher, { wait: true });
     consoleError.mockRestore();
+
+    expect(result).toEqual({ value: "v1", stale: true });
   });
 
   it("propagates the rejection when there is no previous value", async () => {
     const fetcher = vi.fn().mockRejectedValue(new Error("cold start fail"));
 
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     await expect(cached("k", 1_000, fetcher)).rejects.toThrow("cold start fail");
+    consoleError.mockRestore();
   });
 
   it("de-duplicates concurrent misses to a single fetcher call", async () => {
@@ -71,9 +116,29 @@ describe("cached", () => {
     resolveInner("v1");
     const [a, b] = await Promise.all([p1, p2]);
 
-    expect(a).toBe("v1");
-    expect(b).toBe("v1");
+    expect(a).toEqual({ value: "v1", stale: false });
+    expect(b).toEqual({ value: "v1", stale: false });
     expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("de-duplicates concurrent revalidations of a stale entry", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce("v1")
+      .mockResolvedValueOnce("v2");
+
+    await cached("k", 1_000, fetcher);
+    vi.setSystemTime(Date.now() + 1_001);
+
+    const [a, b] = await Promise.all([
+      cached("k", 1_000, fetcher),
+      cached("k", 1_000, fetcher),
+    ]);
+    await vi.runAllTimersAsync();
+
+    expect(a).toEqual({ value: "v1", stale: true });
+    expect(b).toEqual({ value: "v1", stale: true });
+    expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
   it("exposes TTL constants for listening, watching, reading", () => {

--- a/app/lib/cache.server.ts
+++ b/app/lib/cache.server.ts
@@ -1,4 +1,4 @@
-type Entry<T> = { value: T; expiresAt: number };
+type Entry<T> = { value: T; staleAt: number };
 
 const store = new Map<string, Entry<unknown>>();
 const inflight = new Map<string, Promise<unknown>>();
@@ -10,32 +10,54 @@ export const TTL = {
   reading: 12 * 60 * 60_000,
 } as const;
 
+export interface CachedResult<T> {
+  value: T;
+  stale: boolean;
+}
+
 export function cached<T>(
+  key: string,
+  ttlMs: number,
+  fetcher: () => Promise<T>,
+  opts: { wait?: boolean } = {}
+): Promise<CachedResult<T>> {
+  const entry = store.get(key) as Entry<T> | undefined;
+
+  if (entry && Date.now() < entry.staleAt) {
+    return Promise.resolve({ value: entry.value, stale: false });
+  }
+
+  const revalidation = revalidate(key, ttlMs, fetcher);
+
+  if (!entry) {
+    return revalidation.then((value) => ({ value, stale: false }));
+  }
+
+  if (opts.wait) {
+    return revalidation
+      .then((value) => ({ value, stale: false }))
+      .catch(() => ({ value: entry.value, stale: true }));
+  }
+
+  revalidation.catch(() => {});
+  return Promise.resolve({ value: entry.value, stale: true });
+}
+
+function revalidate<T>(
   key: string,
   ttlMs: number,
   fetcher: () => Promise<T>
 ): Promise<T> {
-  const now = Date.now();
-  const entry = store.get(key) as Entry<T> | undefined;
-
-  if (entry && now < entry.expiresAt) {
-    return Promise.resolve(entry.value);
-  }
-
   const existing = inflight.get(key) as Promise<T> | undefined;
   if (existing) return existing;
 
   const pending = fetcher()
     .then((value) => {
-      store.set(key, { value, expiresAt: Date.now() + ttlMs });
+      store.set(key, { value, staleAt: Date.now() + ttlMs });
       return value;
     })
     .catch((err) => {
-      const previous = store.get(key) as Entry<T> | undefined;
-      if (previous) {
-        console.error(`[cache] ${key} serving stale due to:`, err);
-        return previous.value;
-      }
+      console.error(`[cache] revalidate ${key} failed:`, err);
       throw err;
     })
     .finally(() => {

--- a/app/lib/hooks.ts
+++ b/app/lib/hooks.ts
@@ -21,26 +21,41 @@ function useApiData<T>(url: string, interval?: number): UseApiDataState<T> {
 
   const fetchData = async (isInitial = false) => {
     try {
-      setState(prev => ({ 
-        ...prev, 
-        loading: isInitial ? true : prev.data === null, 
-        error: null 
+      setState(prev => ({
+        ...prev,
+        loading: isInitial ? true : prev.data === null,
+        error: null
       }));
       const response = await fetch(url);
-      
+
       if (!response.ok) {
         throw new Error(`Failed to fetch: ${response.statusText}`);
       }
-      
-      const data = await response.json();
+
+      const { data, stale } = await response.json();
       setState({ data, loading: false, error: null, isInitialLoad: false });
+
+      if (stale) {
+        // Stale-while-revalidate: the server answered from cache and is
+        // refreshing in the background; ask again, waiting for fresh data.
+        const freshResponse = await fetch(`${url}?wait=1`);
+        if (freshResponse.ok) {
+          const fresh = await freshResponse.json();
+          setState({
+            data: fresh.data,
+            loading: false,
+            error: null,
+            isInitialLoad: false,
+          });
+        }
+      }
     } catch (error) {
-      setState({ 
-        data: null, 
-        loading: false, 
+      setState(prev => ({
+        data: prev.data,
+        loading: false,
         error: error instanceof Error ? error.message : "An error occurred",
         isInitialLoad: false
-      });
+      }));
     }
   };
 

--- a/app/routes/api.now-listening.ts
+++ b/app/routes/api.now-listening.ts
@@ -1,16 +1,18 @@
+import { LoaderFunctionArgs } from "react-router";
 import { getNowListening } from "~/actions/now-listening.server";
 
-export async function loader() {
+export async function loader({ request }: LoaderFunctionArgs) {
+  const wait = new URL(request.url).searchParams.has("wait");
   try {
-    const data = await getNowListening();
-    return Response.json(data);
+    const { value, stale } = await getNowListening({ wait });
+    return Response.json({ data: value, stale });
   } catch (error) {
     console.error("Error fetching now listening:", error);
     throw new Response(
-      JSON.stringify({ error: "Failed to fetch currently listening" }), 
-      { 
+      JSON.stringify({ error: "Failed to fetch currently listening" }),
+      {
         status: 500,
-        headers: { "Content-Type": "application/json" }
+        headers: { "Content-Type": "application/json" },
       }
     );
   }

--- a/app/routes/api.now-playing.ts
+++ b/app/routes/api.now-playing.ts
@@ -1,9 +1,11 @@
+import { LoaderFunctionArgs } from "react-router";
 import { getNowPlaying } from "~/actions/now-playing.server";
 
-export async function loader() {
+export async function loader({ request }: LoaderFunctionArgs) {
+  const wait = new URL(request.url).searchParams.has("wait");
   try {
-    const data = await getNowPlaying();
-    return Response.json(data);
+    const { value, stale } = await getNowPlaying({ wait });
+    return Response.json({ data: value, stale });
   } catch (error) {
     console.error("Error fetching now playing:", error);
     throw new Response(

--- a/app/routes/api.now-reading.ts
+++ b/app/routes/api.now-reading.ts
@@ -1,16 +1,18 @@
+import { LoaderFunctionArgs } from "react-router";
 import { getNowReading } from "~/actions/now-reading.server";
 
-export async function loader() {
+export async function loader({ request }: LoaderFunctionArgs) {
+  const wait = new URL(request.url).searchParams.has("wait");
   try {
-    const data = await getNowReading();
-    return Response.json(data);
+    const { value, stale } = await getNowReading({ wait });
+    return Response.json({ data: value, stale });
   } catch (error) {
     console.error("Error fetching now reading:", error);
     throw new Response(
-      JSON.stringify({ error: "Failed to fetch currently reading" }), 
-      { 
+      JSON.stringify({ error: "Failed to fetch currently reading" }),
+      {
         status: 500,
-        headers: { "Content-Type": "application/json" }
+        headers: { "Content-Type": "application/json" },
       }
     );
   }

--- a/app/routes/api.now-watching.ts
+++ b/app/routes/api.now-watching.ts
@@ -1,16 +1,18 @@
+import { LoaderFunctionArgs } from "react-router";
 import { getNowWatching } from "~/actions/now-watching.server";
 
-export async function loader() {
+export async function loader({ request }: LoaderFunctionArgs) {
+  const wait = new URL(request.url).searchParams.has("wait");
   try {
-    const data = await getNowWatching();
-    return Response.json(data);
+    const { value, stale } = await getNowWatching({ wait });
+    return Response.json({ data: value, stale });
   } catch (error) {
     console.error("Error fetching now watching:", error);
     throw new Response(
-      JSON.stringify({ error: "Failed to fetch currently watching" }), 
-      { 
+      JSON.stringify({ error: "Failed to fetch currently watching" }),
+      {
         status: 500,
-        headers: { "Content-Type": "application/json" }
+        headers: { "Content-Type": "application/json" },
       }
     );
   }


### PR DESCRIPTION
## Why

The Listening / Reading / Watching / Playing widgets blocked on their third-party APIs (Last.fm, Literal, Letterboxd, gist) every time the server cache TTL expired, so opening the page felt slow until the next refresh.

## What

Stale-while-revalidate, fully server-side:

- `cached()` keeps entries past their TTL and returns `{ value, stale }`. Stale hits answer from cache immediately and trigger a deduplicated background refresh. `{ wait: true }` awaits the refresh and falls back to the stale value if the upstream fails.
- `/api/now-*` routes respond `{ data, stale }`; `?wait=1` waits for the fresh value.
- `useApiData` paints the stale payload instantly, then refetches with `?wait=1` and swaps in the fresh data live. Refresh errors no longer wipe data already on screen.
- All four caches prewarm at server boot, so the first visitor after a deploy or Fly machine wake doesn't wait either.

## Verification

- TDD on the cache: 9 tests written first (7 failing), then implementation — all green.
- Live smoke test against dev server: cache hit answers in ~5ms with `stale: false`; past the 60s listening TTL the endpoint returns `stale: true` instantly and `?wait=1` returns fresh data with `stale: false`.
- Typecheck and lint report only pre-existing issues (identical set on clean HEAD).