### PR TITLE
⚡️ perf: improve Lighthouse mobile score

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -26,31 +26,31 @@ export default function Footer() {
         <div className="flex justify-between items-start gap-2">
           <nav className="flex flex-wrap items-center gap-x-4 gap-y-2 sm:gap-x-6 text-[0.8125rem]">
             <Link
-              className="text-muted-foreground transition-colors hover:text-foreground"
+              className="inline-block py-2 -my-2 text-muted-foreground transition-colors hover:text-foreground"
               to="/"
             >
               Home
             </Link>
             <Link
-              className="text-muted-foreground transition-colors hover:text-foreground"
+              className="inline-block py-2 -my-2 text-muted-foreground transition-colors hover:text-foreground"
               to="/thoughts"
             >
               Thoughts
             </Link>
             <Link
-              className="text-muted-foreground transition-colors hover:text-foreground"
+              className="inline-block py-2 -my-2 text-muted-foreground transition-colors hover:text-foreground"
               to="/bookmarks"
             >
               Bookmarks
             </Link>
             <Link
-              className="text-muted-foreground transition-colors hover:text-foreground"
+              className="inline-block py-2 -my-2 text-muted-foreground transition-colors hover:text-foreground"
               to="/uses"
             >
               Uses
             </Link>
             <Link
-              className="text-muted-foreground transition-colors hover:text-foreground"
+              className="inline-block py-2 -my-2 text-muted-foreground transition-colors hover:text-foreground"
               to="/colophon"
             >
               Colophon
@@ -62,11 +62,11 @@ export default function Footer() {
         </div>
         <button
           onClick={nextQuote}
-          className="hover:cursor-default"
+          className="mt-4 hover:cursor-default"
           type="button"
           aria-label="Show next quote"
         >
-          <blockquote className="mt-4 text-left text-sm leading-7 text-muted-foreground text-pretty font-serif italic">
+          <blockquote className="text-left text-sm leading-7 text-muted-foreground text-pretty font-serif italic">
             {index !== null ? quotes[index] : <QuoteSkeleton />}
           </blockquote>
         </button>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,16 +17,28 @@ import globalStyles from "./styles/globals.css?url";
 import { LinksFunction, LoaderFunctionArgs } from "react-router";
 import AppLayout from "./components/layouts/app-layout";
 import Header from "./components/header";
-import interFont from "@fontsource-variable/inter/index.css?url";
-import newsreaderFont from "@fontsource-variable/newsreader/index.css?url";
+import interLatinWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
+import newsreaderLatinWoff2 from "@fontsource-variable/newsreader/files/newsreader-latin-wght-normal.woff2?url";
 import Footer from "./components/footer";
 import { cn } from "./lib/utils";
 
 export const links: LinksFunction = () => {
   return [
+    {
+      rel: "preload",
+      href: interLatinWoff2,
+      as: "font",
+      type: "font/woff2",
+      crossOrigin: "anonymous",
+    },
+    {
+      rel: "preload",
+      href: newsreaderLatinWoff2,
+      as: "font",
+      type: "font/woff2",
+      crossOrigin: "anonymous",
+    },
     { rel: "stylesheet", href: globalStyles },
-    { rel: "stylesheet", href: interFont },
-    { rel: "stylesheet", href: newsreaderFont },
     // { rel: "icon", type: "image/svg+xml", href: favicon },
   ];
 };

--- a/app/routes/[llms.txt].tsx
+++ b/app/routes/[llms.txt].tsx
@@ -1,0 +1,32 @@
+const llmsText = `# Óscar Córdova
+
+> Personal site of Óscar Córdova, a product-driven engineer and CTO based in Mexico. Writing draws from product engineering, Zen and Taoist philosophy, and Mexican culinary heritage.
+
+## Pages
+
+- [Home](https://cordova.me/): Introduction and what Óscar is doing now
+- [Thoughts](https://cordova.me/thoughts): Essays on product engineering and ways of working
+- [Bookmarks](https://cordova.me/bookmarks): Curated links worth keeping
+- [Uses](https://cordova.me/uses): Tools, hardware, and software he uses
+- [Colophon](https://cordova.me/colophon): How this site is built
+
+## Thoughts
+
+- [Outcomes over output](https://cordova.me/thoughts/outcomes-over-output)
+- [Shifting from code-centric to product-driven](https://cordova.me/thoughts/shifting-from-code-centric-to-product-driven)
+- [The struggle of a product-driven engineer in sales-first companies](https://cordova.me/thoughts/the-struggle-of-a-product-driven-engineer-in-sales-first-companies)
+- [Exploring product-market fit with outcome-focused roadmaps](https://cordova.me/thoughts/exploring-product-market-fit-with-outcome-focused-roadmaps)
+- [Exploring product discovery through one-on-one interviews](https://cordova.me/thoughts/exploring-product-discovery-through-one-on-one-interviews)
+- [Navigating complexity through prioritized sprint backlogs](https://cordova.me/thoughts/navigating-complexity-through-prioritized-sprint-backlogs)
+- [Embracing simplicity in code formatting and linting](https://cordova.me/thoughts/embracing-simplicity-in-code-formatting-and-linting)
+- [Telegram bot with Apps Script](https://cordova.me/thoughts/telegram-bot-with-apps-script)
+`;
+
+export const loader = () => {
+  return new Response(llmsText, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+};

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -1,3 +1,6 @@
+@import "@fontsource-variable/inter";
+@import "@fontsource-variable/newsreader";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Why

Lighthouse mobile scored 90 (Performance), 95 (Accessibility), 2/3 (Agentic Browsing). Main insights: 3 render-blocking stylesheets (~690ms savings), chained font requests, small touch targets in the footer, and `/llms.txt` returning HTTP 500.

## Changes

- **Bundle font CSS**: import `@fontsource-variable/inter` and `@fontsource-variable/newsreader` inside `globals.css` so a single stylesheet ships instead of three.
- **Preload fonts**: `rel="preload"` for the latin woff2 of Inter and Newsreader in root `links`, cutting the HTML → CSS → font request chain. Preload URLs share the hashed asset with the CSS `url()` references, so no double download.
- **Touch targets**: footer nav links get `py-2 -my-2` (taller tap area, same visual layout); quote button now owns the `mt-4` so spacing counts between targets.
- **`/llms.txt`**: new resource route (same pattern as `robots.txt`) serving a Markdown summary of the site.

## Verification

- `npm run build` passes; production server checked locally: single stylesheet, matching preload hashes, `/llms.txt` returns 200.
- `typecheck` failures are pre-existing (leftover Cloudflare `functions/`), confirmed by stashing changes.