### PR TITLE
✨ feat: projects section on the index — Berry Trail

### DIFF
--- a/app/components/projects.tsx
+++ b/app/components/projects.tsx
@@ -1,0 +1,36 @@
+const projects = [
+  {
+    name: "Berry Trail",
+    href: "https://berrytrail.io",
+    description:
+      "A reading room for 13F filings. What 98 superinvestors hold, every quarter since 2013, as filed.",
+  },
+];
+
+const Projects = () => {
+  return (
+    <section className="mt-12">
+      <h2 className="font-serif text-lg font-medium tracking-tight text-foreground">
+        Projects
+      </h2>
+      <div className="mt-2">
+        {projects.map((project) => (
+          <a
+            key={project.name}
+            href={project.href}
+            target="_blank"
+            rel="noreferrer"
+            className="block py-2"
+          >
+            <span className="text-sm link-underline">{project.name}</span>
+            <p className="mt-0.5 text-[0.8125rem] text-muted-foreground">
+              {project.description}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default Projects;

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -4,6 +4,7 @@ import About from "~/components/about";
 import Contact from "~/components/contact";
 import Bookmarks from "~/components/latest-bookmarks";
 import Now from "~/components/now";
+import Projects from "~/components/projects";
 import WorkPhilosophy from "~/components/work-philosophy";
 import { getThoughts } from "~/db/thoughts.server";
 
@@ -32,6 +33,7 @@ export default function Index() {
       <About />
       <WorkPhilosophy />
       <Now />
+      <Projects />
       <section className="mt-12">
         <div className="flex items-center justify-between">
           <h2 className="font-serif text-lg font-medium tracking-tight text-foreground">


### PR DESCRIPTION
## Summary
- Add a Projects section to the index, mirroring the Thoughts pattern: serif heading, one quiet row per project, muted one-line description.
- First entry: [berrytrail.io](https://berrytrail.io).

## Changes
- `app/components/projects.tsx` — new component
- `app/routes/_index.tsx` — render it on the index